### PR TITLE
Remove unused theme toggle

### DIFF
--- a/_includes/layout.html
+++ b/_includes/layout.html
@@ -47,7 +47,6 @@
           <li><a href="{{ '/archive' | url }}">Proof</a></li>
           <li><a href="{{ '/method' | url }}">Method</a></li>
           <li><a href="{{ '/action' | url }}">Action</a></li>
-          <li><button id="theme-toggle" aria-label="Toggle dark mode">🌙</button></li>
           <li><a href="{{ '/about' | url }}">About</a></li>
           <li><a href="{{ '/submit' | url }}" class="btn-nav-submit">Submit</a></li>
           <li>

--- a/script.js
+++ b/script.js
@@ -26,25 +26,12 @@ export function initNavigation() {
     const resetButton = document.getElementById('reset-filters');
     const countEl = document.getElementById('results-count');
     const loadMoreBtn = document.createElement('button');
-    const themeToggle = document.getElementById('theme-toggle');
     
     // Setup Load More button
     loadMoreBtn.className = 'btn btn-outline-blue';
     loadMoreBtn.textContent = 'Load More';
     loadMoreBtn.style.display = 'none';
     loadMoreBtn.style.margin = '32px auto';
-
-     // Theme toggle behavior
-    if (themeToggle) {
-        const current = document.documentElement.getAttribute('data-theme');
-        themeToggle.textContent = current === 'dark' ? '☀️' : '🌙';
-        themeToggle.addEventListener('click', () => {
-            const now = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
-            document.documentElement.setAttribute('data-theme', now);
-            localStorage.setItem('theme', now);
-            themeToggle.textContent = now === 'dark' ? '☀️' : '🌙';
-        });
-    }
     /* ---------- Utility Functions ---------- */
    
 


### PR DESCRIPTION
## Summary
- drop dark-mode toggle button from navigation template
- remove theme toggle variable and listener from script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6da3ffacc83309c344785599e23c4