### PR TITLE
chore: refresh service worker cache

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,13 +1,14 @@
-const CACHE_NAME = 'dj-cache-v1';
+const CACHE_NAME = 'dj-cache-v2';
 const ASSETS_TO_CACHE = [
   '/',
   '/style.css',
-  '/script.js',
+  '/bundle.js',
   '/images/three-dots-blue.svg',
   '/manifest.webmanifest'
 ];
 
 self.addEventListener('install', event => {
+  self.skipWaiting();
   event.waitUntil(
     caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS_TO_CACHE))
   );
@@ -17,7 +18,7 @@ self.addEventListener('activate', event => {
   event.waitUntil(
     caches.keys().then(keys => Promise.all(
       keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
-    ))
+    )).then(() => clients.claim())
   );
 });
 


### PR DESCRIPTION
## Summary
- cache bundled script and bump service worker cache name
- ensure updated service worker activates immediately via `skipWaiting` and `clients.claim`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6e4eaa9f88330bba5ed7e72dbecd4