### PR TITLE
externalize GA consent and add CSP

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -37,6 +37,7 @@ module.exports = function(eleventyConfig) {
   // ## PASSTHROUGH COPIES ##
   eleventyConfig.addPassthroughCopy("style.css");
   eleventyConfig.addPassthroughCopy("script.js");
+  eleventyConfig.addPassthroughCopy("ga-consent.js");
   eleventyConfig.addPassthroughCopy("images");
   eleventyConfig.addPassthroughCopy({ "_data/proofs.json": "data/proofs.json" });
   eleventyConfig.addPassthroughCopy("files");
@@ -45,6 +46,7 @@ module.exports = function(eleventyConfig) {
   // ## WATCH TARGETS ##
   eleventyConfig.addWatchTarget("./style.css");
   eleventyConfig.addWatchTarget("./script.js");
+  eleventyConfig.addWatchTarget("./ga-consent.js");
 
   // ## SERVER OPTIONS ##
   eleventyConfig.setServerOptions({

--- a/_headers
+++ b/_headers
@@ -1,0 +1,3 @@
+/*
+  Content-Security-Policy: script-src 'self' https://www.googletagmanager.com
+

--- a/_includes/layout.html
+++ b/_includes/layout.html
@@ -81,46 +81,7 @@
     </div>
   </footer>
 
-  <script>
-    (function () {
-      const GA_ID = 'G-3TV2GBS34Y';
-
-      function loadGA() {
-        if (window.dataLayer) return;
-        const gtagScript = document.createElement('script');
-        gtagScript.src = `https://www.googletagmanager.com/gtag/js?id=${GA_ID}`;
-        gtagScript.async = true;
-        document.head.appendChild(gtagScript);
-
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        window.gtag = gtag;
-        gtag('js', new Date());
-        gtag('config', GA_ID, { anonymize_ip: true });
-      }
-
-      const consent = localStorage.getItem('analytics-consent');
-      if (consent === 'granted') {
-        loadGA();
-      } else if (consent !== 'denied') {
-        const banner = document.createElement('div');
-        banner.id = 'consent-banner';
-        banner.style.cssText = 'position:fixed;bottom:0;left:0;right:0;background:#eee;padding:1em;text-align:center;z-index:1000;';
-        banner.innerHTML = '<span>We use cookies for analytics.</span> <button id="consent-accept">Accept</button> <button id="consent-reject">Reject</button>';
-        document.body.appendChild(banner);
-        document.getElementById('consent-accept').addEventListener('click', function(){
-          localStorage.setItem('analytics-consent','granted');
-          banner.remove();
-          loadGA();
-        });
-        document.getElementById('consent-reject').addEventListener('click', function(){
-          localStorage.setItem('analytics-consent','denied');
-          banner.remove();
-        });
-      }
-    })();
-  </script>
-
+  <script defer src="/ga-consent.js"></script>
   <!-- Defer so it doesn't block rendering -->
   <script defer src="{{ '/bundle.js' | url }}"></script>
 

--- a/ga-consent.js
+++ b/ga-consent.js
@@ -1,0 +1,37 @@
+(function () {
+  const GA_ID = 'G-3TV2GBS34Y';
+
+  function loadGA() {
+    if (window.dataLayer) return;
+    const gtagScript = document.createElement('script');
+    gtagScript.src = `https://www.googletagmanager.com/gtag/js?id=${GA_ID}`;
+    gtagScript.async = true;
+    document.head.appendChild(gtagScript);
+
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    window.gtag = gtag;
+    gtag('js', new Date());
+    gtag('config', GA_ID, { anonymize_ip: true });
+  }
+
+  const consent = localStorage.getItem('analytics-consent');
+  if (consent === 'granted') {
+    loadGA();
+  } else if (consent !== 'denied') {
+    const banner = document.createElement('div');
+    banner.id = 'consent-banner';
+    banner.style.cssText = 'position:fixed;bottom:0;left:0;right:0;background:#eee;padding:1em;text-align:center;z-index:1000;';
+    banner.innerHTML = '<span>We use cookies for analytics.</span> <button id="consent-accept">Accept</button> <button id="consent-reject">Reject</button>';
+    document.body.appendChild(banner);
+    document.getElementById('consent-accept').addEventListener('click', function(){
+      localStorage.setItem('analytics-consent','granted');
+      banner.remove();
+      loadGA();
+    });
+    document.getElementById('consent-reject').addEventListener('click', function(){
+      localStorage.setItem('analytics-consent','denied');
+      banner.remove();
+    });
+  }
+})();


### PR DESCRIPTION
## Summary
- move GA consent and analytics loader into dedicated `ga-consent.js` and reference from layout
- serve consent script as static asset and pass through Eleventy
- configure CSP header allowing Google Tag Manager scripts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e9627a208330b50d19c55c4d69bb