### PR TITLE
Add PostCSS build step with autoprefixing and minification

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "scripts": {
     "start": "eleventy --serve",
     "dev": "eleventy --serve",
-     "build:js": "esbuild src/main.js --bundle --minify --outfile=bundle.js",
-    "build": "npm run build:js && eleventy",
+    "build:js": "esbuild src/main.js --bundle --minify --outfile=bundle.js",
+    "build:css": "postcss _site/style.css -o _site/style.css",
+    "build": "npm run build:js && eleventy && npm run build:css",
     "test": "echo no-tests && exit 0"
   },
   "keywords": [],
@@ -18,6 +19,10 @@
   },
   "devDependencies": {
     "luxon": "^3.7.2",
-    "esbuild": "^0.21.0"
+    "esbuild": "^0.21.0",
+    "postcss": "^8.5.6",
+    "postcss-cli": "^11.0.1",
+    "autoprefixer": "^10.4.21",
+    "cssnano": "^7.1.1"
   }
 }

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: [
+    require('autoprefixer'),
+    require('cssnano')({ preset: 'default' })
+  ]
+};


### PR DESCRIPTION
## Summary
- build CSS with PostCSS using autoprefixer and cssnano
- run PostCSS after Eleventy build to minify `_site/style.css`
- include PostCSS config and dev dependencies

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6ed8fdef8833087e72bc626d16eeb