### PR TITLE
Preload Google Fonts for faster first paint

### DIFF
--- a/_includes/layout.html
+++ b/_includes/layout.html
@@ -20,9 +20,14 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Oswald:wght@600;700&display=swap">
+  <link rel="preload" as="font" href="https://fonts.gstatic.com/s/lato/v24/S6uyw4BMUTPHvxk.ttf" type="font/ttf" crossorigin>
+  <link rel="preload" as="font" href="https://fonts.gstatic.com/s/lato/v24/S6u9w4BMUTPHh6UVew8.ttf" type="font/ttf" crossorigin>
+  <link rel="preload" as="font" href="https://fonts.gstatic.com/s/oswald/v57/TK3_WkUHHAIjg75cFRf3bXL8LICs1y9ogUE.ttf" type="font/ttf" crossorigin>
+  <link rel="preload" as="font" href="https://fonts.gstatic.com/s/oswald/v57/TK3_WkUHHAIjg75cFRf3bXL8LICs1xZogUE.ttf" type="font/ttf" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Oswald:wght@600;700&display=swap">
   <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
   <link rel="dns-prefetch" href="https://www.googletagmanager.com">
-  <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Oswald:wght@600;700&display=swap" rel="stylesheet">
 
   <!-- Root-relative assets (safe from any page depth and pathPrefix-aware) -->
   <link rel="icon" href="{{ '/images/three-dots-blue.svg' | url }}" type="image/svg+xml">


### PR DESCRIPTION
## Summary
- preload Google Fonts stylesheet and font files
- ensure fonts use `font-display: swap` to avoid blocking rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6ef0632dc8330ba98f92fa405da49