### PR TITLE
feat: avoid mid-word truncation

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -31,7 +31,8 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addFilter("truncate", (str, length = 150) => {
     if (!str) return "";
     if (str.length <= length) return str;
-    return str.substr(0, length) + "...";
+    const idx = str.lastIndexOf(" ", length);
+    return str.slice(0, idx > 0 ? idx : length) + "…";
   });
 
   // ## PASSTHROUGH COPIES ##


### PR DESCRIPTION
## Summary
- truncate filter trims at word boundary instead of cutting mid-word

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f85b146c8330b542636b99e18623