### PR TITLE
Add privacy policy page and footer link

### DIFF
--- a/_includes/layout.html
+++ b/_includes/layout.html
@@ -78,6 +78,7 @@
       <p><strong>Proof. Not Spin.</strong></p>
       <p>A 100% volunteer-run project. We do not solicit or accept financial contributions. We do not endorse candidates.</p>
       <p><a href="mailto:setho@democraticjustice.org">Submit Proof Confidentially</a></p>
+      <p><a href="{{ '/privacy' | url }}">Privacy Policy</a></p>
 
       <img class="mark xl"
            src="{{ '/images/three-dots-gold.svg' | url }}"

--- a/privacy.njk
+++ b/privacy.njk
@@ -1,0 +1,17 @@
+---
+layout: layout.html
+title: "Privacy Policy — Democratic Justice"
+description: "How we handle your data and cookies."
+permalink: /privacy/
+---
+
+<section class="content-page" id="privacy-page">
+  <div class="align-container">
+    <h1>Privacy Policy</h1>
+    <p>We collect only the information needed to operate this site. A small cookie stored in your browser remembers whether you have granted consent for analytics.</p>
+    <p>Analytics are provided by Google Analytics. Data is anonymized and used to understand aggregate site usage so we can improve content. No personal information is sold or shared for marketing purposes.</p>
+    <p>You can change your consent at any time by clearing your browser's local storage or using a different browser or device.</p>
+    <p>For questions, contact <a href="mailto:setho@democraticjustice.org">setho@democraticjustice.org</a>.</p>
+    <p>This policy may be updated from time to time. Check this page for the latest information.</p>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- add privacy policy page outlining data collection and consent
- link footer to new privacy policy for easy discovery

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6fa6eb7048330bfe3603e6b88ccb1