### PR TITLE
Use white logos and navy proof card text

### DIFF
--- a/_includes/layout.html
+++ b/_includes/layout.html
@@ -44,7 +44,7 @@
         <div class="logo-wrap">
           <a href="{{ '/' | url }}" aria-label="Democratic Justice home">
             <img class="wordmark"
-                 src="{{ '/images/wordmark-blue-on-white.svg' | url }}"
+                 src="{{ '/images/wordmark-white-on-blue.svg' | url }}"
                  alt="Democratic Justice">
           </a>
         </div>
@@ -56,7 +56,7 @@
           <li><a href="{{ '/submit' | url }}" class="btn-nav-submit">Submit</a></li>
           <li>
             <img class="mark xl"
-                 src="{{ '/images/three-dots-blue.svg' | url }}"
+                 src="{{ '/images/three-dots-white.svg' | url }}"
                  alt="" aria-hidden="true">
           </li>
         </ul>

--- a/style.css
+++ b/style.css
@@ -225,7 +225,7 @@ p{max-width:65ch;margin-bottom:16px}
 /* Proof Box */
 .proof-box{
   background:#fff;
-  color:var(--text);
+  color:var(--navy);
   border-radius:12px;
   overflow:hidden;
   box-shadow:0 0 0 3px rgba(255,255,255,0.1), 0 14px 32px rgba(0,0,0,.25);
@@ -259,7 +259,7 @@ p{max-width:65ch;margin-bottom:16px}
   margin-bottom:12px;
 }
 .proof-box__meta{
-  color:var(--muted);
+  color:var(--navy);
   font-size:14px;
   margin-bottom:16px;
 }


### PR DESCRIPTION
## Summary
- Switch site navigation logos to white image versions for contrast
- Adjust proof card styling so copy is rendered in the navy brand color

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7031ed27083308a91c3c6d79dfc17