### PR TITLE
Improve nav toggle contrast and accessibility

### DIFF
--- a/_includes/layout.html
+++ b/_includes/layout.html
@@ -44,14 +44,16 @@
         <div class="logo-wrap">
           <a href="{{ '/' | url }}" aria-label="Democratic Justice home">
             <img class="wordmark"
-                 src="{{ '/images/wordmark-white-on-blue.svg' | url }}"
+                 src="{{ '/images/wordmark-blue-on-white.svg' | url }}"
                  alt="Democratic Justice">
           </a>
         </div>
         <button class="nav-toggle" type="button" aria-expanded="false" aria-label="Menu" aria-controls="primary-nav">
-          <img class="mark xl"
-               src="{{ '/images/three-dots-white.svg' | url }}"
-               alt="" aria-hidden="true">
+          <svg class="mark xl" aria-hidden="true" viewBox="0 0 9.45 8" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path d="M4.28,5.47c0,.56-.45,1.01-1.01,1.01s-1.01-.45-1.01-1.01.45-1.01,1.01-1.01,1.01.45,1.01,1.01ZM5.77,2.43c0,.56-.45,1.01-1.01,1.01s-1.02-.45-1.02-1.01.45-1.01,1.02-1.01,1.01.45,1.01,1.01ZM7.27,5.5c0,.55-.45.99-1.01.99s-1.01-.44-1.01-.99.45-.99,1.01-.99,1.01.44,1.01.99Z"/>
+            <path d="M7.27,7.53h1.09V.48h-1.09v-.48h2.18v8h-2.18v-.47Z"/>
+            <path d="M2.18,7.53h-1.09V.48h1.09v-.48H0v8h2.18v-.47Z"/>
+          </svg>
         </button>
         <ul class="nav-links" id="primary-nav">
           <li><a href="{{ '/archive' | url }}">Proof</a></li>

--- a/style.css
+++ b/style.css
@@ -147,6 +147,11 @@ p{max-width:65ch;margin-bottom:16px}
   background:none;
   border:none;
   cursor:pointer;
+  min-width:44px;
+  min-height:44px;
+  color:var(--navy);
+  align-items:center;
+  justify-content:center;
 }
 
 @media (max-width:768px){
@@ -166,7 +171,7 @@ p{max-width:65ch;margin-bottom:16px}
     display:flex;
   }
   .nav-toggle{
-    display:block;
+    display:flex;
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace white nav toggle icon with inline SVG and switch to blue wordmark for light headers
- Enforce 44px minimum size and high-contrast color on `.nav-toggle`

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c792529e90833094b5a18ccf52aee2