### PR TITLE
Improve case summary layout for mobile

### DIFF
--- a/case.njk
+++ b/case.njk
@@ -43,16 +43,16 @@ eleventyComputed:
         <div class="proof-summary-grid">
           <div class="proof-summary-item">
             <span class="proof-summary-label">Violation:</span>
-            <span class="proof-summary-text">{{ proof.violation | truncate(150) | safe }}</span>
+            <span class="proof-summary-text">{{ proof.violation | safe }}</span>
           </div>
           <div class="proof-summary-item">
             <span class="proof-summary-label">Stakes:</span>
-            <span class="proof-summary-text">{{ proof.stakes | truncate(150) | safe }}</span>
+            <span class="proof-summary-text">{{ proof.stakes | safe }}</span>
           </div>
           {% if proof.potential_remedies %}
           <div class="proof-summary-item">
             <span class="proof-summary-label">Remedy:</span>
-            <span class="proof-summary-text">{{ proof.potential_remedies[0] | truncate(150) | safe }}</span>
+            <span class="proof-summary-text">{{ proof.potential_remedies[0] | safe }}</span>
           </div>
           {% endif %}
         </div>
@@ -174,7 +174,33 @@ eleventyComputed:
             <img src="{{ '/images/icon-print.svg' | url }}" alt="Print">
           </button>
         </div>
-      </section>
+  </section>
     </div>
   </article>
 </div>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.proof-summary-text').forEach(function (text) {
+    var lineHeight = parseFloat(getComputedStyle(text).lineHeight);
+    var maxLines = 3;
+    if (text.scrollHeight > lineHeight * maxLines) {
+      text.classList.add('clamp');
+      var btn = document.createElement('button');
+      btn.className = 'read-more';
+      btn.textContent = 'Read more';
+      btn.setAttribute('aria-expanded', 'false');
+      btn.addEventListener('click', function () {
+        var expanded = text.classList.toggle('expanded');
+        btn.textContent = expanded ? 'Read less' : 'Read more';
+        btn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+        if (expanded) {
+          text.classList.remove('clamp');
+        } else {
+          text.classList.add('clamp');
+        }
+      });
+      text.after(btn);
+    }
+  });
+});
+</script>

--- a/style.css
+++ b/style.css
@@ -2047,6 +2047,47 @@ html { scroll-behavior: smooth; }
   line-height: 1.5;
   color: var(--text);
 }
+.proof-summary-text.clamp {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.proof-summary-text.expanded {
+  -webkit-line-clamp: unset;
+}
+.read-more {
+  margin-top: 4px;
+  background: none;
+  border: none;
+  color: var(--brand);
+  cursor: pointer;
+  font-size: 16px;
+  padding: 0;
+}
+
+@media (max-width:600px){
+  .case-grid{
+    grid-template-columns:1fr;
+  }
+  .case-card{
+    padding:16px;
+  }
+  .proof-summary-grid{
+    gap:8px;
+  }
+  .proof-summary-item{
+    flex-direction:column;
+    gap:4px;
+  }
+  .proof-summary-label{
+    font-size:16px;
+    min-width:auto;
+  }
+  .proof-summary-text{
+    font-size:16px;
+  }
+}
 
 /* ===== Proof Strength Indicator ===== */
 .proof-strength {


### PR DESCRIPTION
## Summary
- Remove truncation from case summaries and add optional "Read more" toggle.
- Add mobile breakpoint to collapse case grid and reduce card padding.
- Stack proof summary labels above text on small screens with larger fonts and tighter spacing.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c795bc488883309d41a07957f4aa75