### PR TITLE
refactor: adopt mobile-first responsive breakpoints

### DIFF
--- a/style.css
+++ b/style.css
@@ -111,10 +111,20 @@ p{max-width:65ch;margin-bottom:16px}
 }
 .logo-wrap{display:flex;align-items:center;gap:12px}
 .nav-links{
-  display:flex;
-  align-items:center;
-  gap:24px;
+  display:none;
+  flex-direction:column;
+  position:absolute;
+  top:100%;
+  left:0;
+  right:0;
+  background:var(--white);
+  padding:16px 20px;
+  gap:12px;
+  box-shadow:0 4px 8px rgba(0,0,0,.1);
   list-style:none;
+}
+.nav.nav--open .nav-links{
+  display:flex;
 }
 .nav-links a{
   color:var(--brand);
@@ -143,7 +153,7 @@ p{max-width:65ch;margin-bottom:16px}
 }
 
 .nav-toggle{
-  display:none;
+  display:flex;
   background:none;
   border:none;
   cursor:pointer;
@@ -154,24 +164,22 @@ p{max-width:65ch;margin-bottom:16px}
   justify-content:center;
 }
 
-@media (max-width:768px){
+@media (min-width:769px){
   .nav-links{
-    display:none;
-    flex-direction:column;
-    position:absolute;
-    top:100%;
-    left:0;
-    right:0;
-    background:var(--white);
-    padding:16px 20px;
-    gap:12px;
-    box-shadow:0 4px 8px rgba(0,0,0,.1);
-  }
-  .nav.nav--open .nav-links{
     display:flex;
+    flex-direction:row;
+    position:static;
+    top:auto;
+    left:auto;
+    right:auto;
+    background:transparent;
+    padding:0;
+    gap:24px;
+    box-shadow:none;
+    align-items:center;
   }
   .nav-toggle{
-    display:flex;
+    display:none;
   }
 }
 
@@ -197,20 +205,15 @@ p{max-width:65ch;margin-bottom:16px}
   position: relative;
 }
 
-/* Keep for clarity; still solid on desktop */
-@media (min-width: 900px){
-  .hero{ background-color: var(--navy); }
-}
-
 /* Hero grid */
 .hero-grid{
   display: grid;
-  grid-template-columns: 1.3fr 1fr;
+  grid-template-columns: 1fr;
   gap: var(--gap);
   align-items: center;
 }
-@media (max-width: 768px){
-  .hero-grid{ grid-template-columns: 1fr; }
+@media (min-width:769px){
+  .hero-grid{ grid-template-columns: 1.3fr 1fr; }
 }
 /* Buttons */
 .btn{
@@ -339,7 +342,7 @@ p{max-width:65ch;margin-bottom:16px}
 }
 .case-grid{
   display:grid;
-  grid-template-columns:repeat(auto-fit,minmax(320px,1fr));
+  grid-template-columns:1fr;
   gap:24px;
   margin-top:var(--gap);
 }
@@ -348,7 +351,7 @@ p{max-width:65ch;margin-bottom:16px}
   border:1px solid color-mix(in srgb, var(--silver) 30%, transparent);
   border-left:4px solid var(--navy);
   border-radius:10px;
-  padding:24px;
+  padding:16px;
   transition:transform .2s,box-shadow .2s;
   box-shadow:0 2px 8px rgba(15,39,66,.05);
 }
@@ -623,7 +626,7 @@ p{max-width:65ch;margin-bottom:16px}
 /* Search and Filter Controls */
 .search-filter-controls {
   display: grid;
-  grid-template-columns: 2fr 1fr;
+  grid-template-columns: 1fr;
   gap: 16px;
   margin: 32px 0;
   align-items: center;
@@ -717,15 +720,16 @@ p{max-width:65ch;margin-bottom:16px}
 }
 .case-meta-bar {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
   margin-bottom: 12px;
 }
 
 /* Responsive adjustments for search */
-@media (max-width: 768px) {
-  .search-filter-controls { grid-template-columns: 1fr; }
-  .case-meta-bar { flex-direction: column; align-items: flex-start; gap: 8px; }
+@media (min-width:769px) {
+  .search-filter-controls { grid-template-columns: 2fr 1fr; }
+  .case-meta-bar { flex-direction: row; align-items: center; gap: 0; }
 }
 
 /* Section wrapper padding (all breakpoints) */
@@ -746,17 +750,23 @@ html { scroll-behavior: smooth; }
 
 /* Shortcut nav */
 .action-shortcuts {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  display: flex;
+  overflow-x: auto;
   gap: .5rem;
+  padding-bottom: .25rem;
+  -webkit-overflow-scrolling: touch;
   margin: 1rem 0 1.5rem;
 }
-@media (max-width: 640px) {
+.action-shortcuts a { flex: 0 0 auto; }
+
+@media (min-width:601px) {
   .action-shortcuts {
-    display: flex; overflow-x: auto; gap: .5rem; padding-bottom: .25rem;
-    -webkit-overflow-scrolling: touch;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    overflow: visible;
+    padding-bottom: 0;
   }
-  .action-shortcuts a { flex: 0 0 auto; }
+  .action-shortcuts a { flex: initial; }
 }
 .action-shortcuts a {
   display: inline-block;
@@ -1192,11 +1202,16 @@ html { scroll-behavior: smooth; }
 /* Lock background scroll when open */
 .body--modal-open { overflow: hidden; }
 
-@media (max-width: 768px) {
-  .modal-content { width: 95%; max-height: 95vh; margin: 10px; }
-  .modal-header { padding: 24px; }
-  .modal-body { padding: 24px; }
-  .modal-close { right: 15px; top: 15px; width: 35px; height: 35px; font-size: 24px; }
+.modal-content { width: 95%; max-height: 95vh; margin: 10px; }
+.modal-header { padding: 24px; }
+.modal-body { padding: 24px; }
+.modal-close { right: 15px; top: 15px; width: 35px; height: 35px; font-size: 24px; }
+
+@media (min-width:769px) {
+  .modal-content { width: 90%; max-width: 700px; max-height: 90vh; margin: 0; }
+  .modal-header { padding: 30px; }
+  .modal-body { padding: 30px; }
+  .modal-close { right: 20px; top: 20px; width: 40px; height: 40px; font-size: 28px; }
 }
 
 /* Respect reduced motion */
@@ -1218,9 +1233,9 @@ html { scroll-behavior: smooth; }
 #proof-page .align-container{ max-width:1100px; margin:0 auto; padding:0 32px; }
 
 /* Steps layout (4→2→1 responsive) */
-.steps-grid{ display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:24px; }
-@media (max-width:1024px){ .steps-grid{ grid-template-columns:repeat(2,minmax(0,1fr)); } }
-@media (max-width:640px){ .steps-grid{ grid-template-columns:1fr; } }
+.steps-grid{ display:grid; grid-template-columns:1fr; gap:24px; }
+@media (min-width:601px){ .steps-grid{ grid-template-columns:repeat(2,minmax(0,1fr)); } }
+@media (min-width:993px){ .steps-grid{ grid-template-columns:repeat(4,minmax(0,1fr)); } }
 /* Buttons */
 .btn{
   display:inline-flex; align-items:center; justify-content:center;
@@ -1235,9 +1250,9 @@ html { scroll-behavior: smooth; }
 .btn--on-dark:hover{ filter: brightness(.96); }
 
 /* Steps grid remains responsive */
-.steps-grid{ display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:24px; }
-@media (max-width:1024px){ .steps-grid{ grid-template-columns:repeat(2,minmax(0,1fr)); } }
-@media (max-width:640px){ .steps-grid{ grid-template-columns:1fr; } }
+.steps-grid{ display:grid; grid-template-columns:1fr; gap:24px; }
+@media (min-width:601px){ .steps-grid{ grid-template-columns:repeat(2,minmax(0,1fr)); } }
+@media (min-width:993px){ .steps-grid{ grid-template-columns:repeat(4,minmax(0,1fr)); } }
 /* ===== One-Page Proof Architecture ===== */
 #proof-page .align-container{ max-width:1100px; margin:0 auto; padding:0 32px; }
 
@@ -1269,7 +1284,7 @@ html { scroll-behavior: smooth; }
 
 /* Axioms */
 .axioms{ margin:28px 0 16px; }
-.axiom-grid{ list-style:none; padding:0; margin:0; display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:18px; }
+.axiom-grid{ list-style:none; padding:0; margin:0; display:grid; grid-template-columns:1fr; gap:18px; }
 .axiom-card{
   background: var(--paper,#fff); border:1px solid rgba(0,0,0,.08);
   border-radius:14px; padding:16px 16px 14px; position:relative; box-shadow:0 10px 24px rgba(0,0,0,.12);
@@ -1281,7 +1296,7 @@ html { scroll-behavior: smooth; }
 
 /* Evidence Chain */
 .evidence-chain h2{ margin:24px 0 12px; }
-.chain{ list-style:none; padding:0; margin:0; display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:18px; align-items:start; }
+.chain{ list-style:none; padding:0; margin:0; display:grid; grid-template-columns:1fr; gap:18px; align-items:start; }
 .chain-step{ background: var(--paper,#fff); border:1px solid rgba(0,0,0,.08); border-radius:14px; padding:14px; box-shadow:0 10px 24px rgba(0,0,0,.12); }
 .chain-step__head{ display:flex; align-items:center; gap:10px; margin-bottom:8px; }
 .chain-step__num{ width:28px; height:28px; display:grid; place-items:center; border-radius:8px; background:var(--brand); color:#fff; font-weight:700; font-size:.9rem; }
@@ -1298,7 +1313,7 @@ html { scroll-behavior: smooth; }
 
 /* Contradiction Reveal */
 .reveal h2{ margin:24px 0 12px; }
-.split{ display:grid; grid-template-columns:1fr 1fr; gap:18px; }
+.split{ display:grid; grid-template-columns:1fr; gap:18px; }
 .split__pane{ background: var(--paper,#fff); border:1px solid rgba(0,0,0,.08); border-radius:14px; padding:16px; box-shadow:0 10px 24px rgba(0,0,0,.12); }
 .split__pane--actual h3{ color:#d92d20; } /* red only for the violation moment */
 
@@ -1315,14 +1330,14 @@ html { scroll-behavior: smooth; }
 .falsifiability li{ margin:4px 0; }
 
 /* Responsive */
-@media (max-width: 1100px){
+@media (min-width:601px){
   .axiom-grid{ grid-template-columns:1fr 1fr; }
   .chain{ grid-template-columns:1fr 1fr; }
-  .split{ grid-template-columns:1fr; }
 }
-@media (max-width: 640px){
-  .axiom-grid{ grid-template-columns:1fr; }
-  .chain{ grid-template-columns:1fr; }
+@media (min-width:1201px){
+  .axiom-grid{ grid-template-columns:repeat(3,minmax(0,1fr)); }
+  .chain{ grid-template-columns:repeat(4,minmax(0,1fr)); }
+  .split{ grid-template-columns:1fr 1fr; }
 }
 
 /* Print (one-page lean) */
@@ -1380,7 +1395,7 @@ html { scroll-behavior: smooth; }
 
 /* Axioms */
 .axioms{ margin:18px 0 8px; }
-.axiom-grid{ list-style:none; padding:0; margin:0; display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:16px; }
+.axiom-grid{ list-style:none; padding:0; margin:0; display:grid; grid-template-columns:1fr; gap:16px; }
 .axiom-card{ background:#fff; border:1px solid #e5e7eb; border-radius:10px; padding:14px 14px 12px; position:relative; }
 .axiom-bar{ position:absolute; left:0; right:0; bottom:-5px; height:5px; background:#eceff3; border-radius:0 0 10px 10px; }
 .axiom-title{ margin:0 0 6px; font-weight:700; }
@@ -1389,7 +1404,7 @@ html { scroll-behavior: smooth; }
 
 /* Evidence chain */
 .evidence-chain h2{ margin:18px 0 10px; }
-.chain{ list-style:none; padding:0; margin:0; display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:16px; }
+.chain{ list-style:none; padding:0; margin:0; display:grid; grid-template-columns:1fr; gap:16px; }
 .chain-step{ border:1px solid #e5e7eb; border-radius:10px; padding:12px; background:#fff; }
 .chain-step__head{ display:flex; align-items:center; gap:10px; margin-bottom:6px; }
 .chain-step__num{ width:26px; height:26px; border-radius:7px; display:grid; place-items:center; background:var(--brand); color:#fff; font-weight:700; font-size:.9rem; }
@@ -1406,7 +1421,7 @@ html { scroll-behavior: smooth; }
 
 /* Reveal */
 .reveal h2{ margin:18px 0 10px; }
-.split{ display:grid; grid-template-columns:1fr 1fr; gap:16px; }
+.split{ display:grid; grid-template-columns:1fr; gap:16px; }
 .split__pane{ border:1px solid #e5e7eb; border-radius:10px; padding:14px; background:#fff; }
 .split__pane--actual h3{ color:#d92d20; }
 
@@ -1427,13 +1442,14 @@ html { scroll-behavior: smooth; }
 }
 
 /* Responsive */
-@media (max-width:1100px){
+@media (min-width:601px){
   .axiom-grid{ grid-template-columns:1fr 1fr; }
   .chain{ grid-template-columns:1fr 1fr; }
-  .split{ grid-template-columns:1fr; }
 }
-@media (max-width:640px){
-  .axiom-grid, .chain{ grid-template-columns:1fr; }
+@media (min-width:1201px){
+  .axiom-grid{ grid-template-columns:repeat(3,minmax(0,1fr)); }
+  .chain{ grid-template-columns:repeat(4,minmax(0,1fr)); }
+  .split{ grid-template-columns:1fr 1fr; }
 }
 
 /* Print */
@@ -1819,30 +1835,35 @@ html { scroll-behavior: smooth; }
    MEDIA QUERIES: PROOF DOCUMENT
    =============================================== */
 
-@media (max-width: 768px) {
-  .doc-header,
-  .doc-body {
-    padding: 24px;
-  }
+.doc-header,
+.doc-body {
+  padding: 24px;
+}
 
-  .doc-title {
-    font-size: 1.75rem;
-  }
+.doc-title {
+  font-size: 1.75rem;
+}
 
-  .section-title {
-    font-size: 1.375rem;
-    padding-left: 0;
-  }
+.section-title {
+  font-size: 1.375rem;
+  padding-left: 0;
+}
 
-  .section-title::before {
-    display: none;
-  }
+.section-title::before {
+  display: none;
+}
 
-  .violation {
-    margin-left: 0;
-    margin-right: 0;
-  }
+.violation {
+  margin-left: 0;
+  margin-right: 0;
+}
 
+@media (min-width:769px) {
+  .doc-header { padding: 32px 32px 32px; }
+  .doc-body { padding: 0 32px 32px; }
+  .doc-title { font-size: clamp(2rem, 4vw, 3rem); }
+  .section-title { font-size: 1.75rem; }
+  .section-title::before { display: block; }
 }
 
 .filter-badges {
@@ -2025,27 +2046,29 @@ html { scroll-behavior: smooth; }
 }
 .proof-summary-grid {
   display: grid;
-  gap: 16px;
+  gap: 8px;
   margin-top: 8px;
 }
 .proof-summary-item {
   display: flex;
-  gap: 12px;
+  flex-direction: column;
+  gap: 4px;
   align-items: flex-start;
 }
 .proof-summary-label {
   flex-shrink: 0;
   font-weight: 700;
   text-transform: uppercase;
-  font-size: 12px;
+  font-size: 16px;
   letter-spacing: 0.5px;
   color: var(--navy);
-  min-width: 80px;
+  min-width: auto;
 }
 .proof-summary-text {
   flex: 1;
   line-height: 1.5;
   color: var(--text);
+  font-size: 16px;
 }
 .proof-summary-text.clamp {
   display: -webkit-box;
@@ -2066,27 +2089,13 @@ html { scroll-behavior: smooth; }
   padding: 0;
 }
 
-@media (max-width:600px){
-  .case-grid{
-    grid-template-columns:1fr;
-  }
-  .case-card{
-    padding:16px;
-  }
-  .proof-summary-grid{
-    gap:8px;
-  }
-  .proof-summary-item{
-    flex-direction:column;
-    gap:4px;
-  }
-  .proof-summary-label{
-    font-size:16px;
-    min-width:auto;
-  }
-  .proof-summary-text{
-    font-size:16px;
-  }
+@media (min-width:601px){
+  .case-grid{ grid-template-columns:repeat(auto-fit,minmax(320px,1fr)); }
+  .case-card{ padding:24px; }
+  .proof-summary-grid{ gap:16px; }
+  .proof-summary-item{ flex-direction:row; gap:12px; }
+  .proof-summary-label{ font-size:12px; min-width:80px; }
+  .proof-summary-text{ font-size:inherit; }
 }
 
 /* ===== Proof Strength Indicator ===== */


### PR DESCRIPTION
## Summary
- switch navigation and hero layout to mobile-first styling
- standardize responsive breakpoints using 2025 min-width ranges
- clean up case and proof layouts to align with new mobile defaults

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c79bd4871c8330ad3ef4a365017589