### PR TITLE
Add responsive bottom navigation

### DIFF
--- a/_data/site.json
+++ b/_data/site.json
@@ -1,3 +1,4 @@
 {
-  "url": "https://democraticjustice.org"
+  "url": "https://democraticjustice.org",
+  "mobileNavBreakpoint": 768
 }

--- a/_includes/bottom-nav.html
+++ b/_includes/bottom-nav.html
@@ -1,0 +1,9 @@
+<nav class="bottom-nav" aria-label="Primary">
+  <ul class="bottom-nav-links">
+    <li><a href="{{ '/' | url }}" aria-label="Home">Home</a></li>
+    <li><a href="{{ '/archive' | url }}">Proof</a></li>
+    <li><a href="{{ '/method' | url }}">Method</a></li>
+    <li><a href="{{ '/action' | url }}">Action</a></li>
+    <li><a href="{{ '/submit' | url }}">Submit</a></li>
+  </ul>
+</nav>

--- a/_includes/layout.html
+++ b/_includes/layout.html
@@ -70,6 +70,10 @@
     {{ content }}
   </main>
 
+  {% if site.mobileNavBreakpoint %}
+    {% include "bottom-nav.html" %}
+  {% endif %}
+
   <footer class="footer">
     <div class="align-container">
       <div class="footer-top">

--- a/style.css
+++ b/style.css
@@ -196,6 +196,48 @@ p{max-width:65ch;margin-bottom:16px}
   }
 }
 
+.bottom-nav{
+  display:none;
+  position:fixed;
+  bottom:0;
+  left:0;
+  right:0;
+  background:var(--brand);
+  color:var(--white);
+  z-index:100;
+  box-shadow:0 -2px 8px rgba(15,39,66,.08);
+  padding-bottom:env(safe-area-inset-bottom);
+}
+.bottom-nav-links{
+  display:flex;
+  justify-content:space-around;
+  list-style:none;
+  margin:0;
+  padding:0;
+}
+.bottom-nav-links a{
+  flex:1;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  color:var(--white);
+  font-weight:700;
+  text-transform:uppercase;
+  font-size:14px;
+  letter-spacing:.5px;
+  text-decoration:none;
+  min-width:44px;
+  min-height:44px;
+}
+.bottom-nav-links a:focus-visible{
+  outline:2px solid var(--accent-600);
+  outline-offset:2px;
+}
+@media (max-width:768px){
+  .bottom-nav{display:flex;}
+  .nav{display:none;}
+}
+
 /* Theme toggle button */
 #theme-toggle{
   background:none;


### PR DESCRIPTION
## Summary
- add `_includes/bottom-nav.html` with key site links
- conditionally include bottom bar in layout for small viewports
- style bottom bar and hide top nav on narrow screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7a5699d2c83308c102c4db33b24fe