### PR TITLE
Link micro marks to homepage and update footer logo color

### DIFF
--- a/_includes/layout.html
+++ b/_includes/layout.html
@@ -49,11 +49,13 @@
           </a>
         </div>
         <button class="nav-toggle" type="button" aria-expanded="false" aria-label="Menu" aria-controls="primary-nav">
-          <svg class="mark xl" aria-hidden="true" viewBox="0 0 9.45 8" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-            <path d="M4.28,5.47c0,.56-.45,1.01-1.01,1.01s-1.01-.45-1.01-1.01.45-1.01,1.01-1.01,1.01.45,1.01,1.01ZM5.77,2.43c0,.56-.45,1.01-1.01,1.01s-1.02-.45-1.02-1.01.45-1.01,1.02-1.01,1.01.45,1.01,1.01ZM7.27,5.5c0,.55-.45.99-1.01.99s-1.01-.44-1.01-.99.45-.99,1.01-.99,1.01.44,1.01.99Z"/>
-            <path d="M7.27,7.53h1.09V.48h-1.09v-.48h2.18v8h-2.18v-.47Z"/>
-            <path d="M2.18,7.53h-1.09V.48h1.09v-.48H0v8h2.18v-.47Z"/>
-          </svg>
+          <a href="{{ '/' | url }}" aria-label="Democratic Justice home">
+            <svg class="mark xl" aria-hidden="true" viewBox="0 0 9.45 8" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+              <path d="M4.28,5.47c0,.56-.45,1.01-1.01,1.01s-1.01-.45-1.01-1.01.45-1.01,1.01-1.01,1.01.45,1.01,1.01ZM5.77,2.43c0,.56-.45,1.01-1.01,1.01s-1.02-.45-1.02-1.01.45-1.01,1.02-1.01,1.01.45,1.01,1.01ZM7.27,5.5c0,.55-.45.99-1.01.99s-1.01-.44-1.01-.99.45-.99,1.01-.99,1.01.44,1.01.99Z"/>
+              <path d="M7.27,7.53h1.09V.48h-1.09v-.48h2.18v8h-2.18v-.47Z"/>
+              <path d="M2.18,7.53h-1.09V.48h1.09v-.48H0v8h2.18v-.47Z"/>
+            </svg>
+          </a>
         </button>
         <ul class="nav-links" id="primary-nav">
           <li><a href="{{ '/archive' | url }}">Proof</a></li>
@@ -87,11 +89,13 @@
       <p><a href="mailto:setho@democraticjustice.org">Submit Proof Confidentially</a></p>
       <p><a href="{{ '/privacy' | url }}">Privacy Policy</a></p>
 
-      <img class="mark xl"
-           src="{{ '/images/three-dots-gold.svg' | url }}"
-           alt="" aria-hidden="true"
-           loading="lazy" decoding="async"
-           style="position:absolute; bottom: var(--gap); right: 20px; opacity: 0.5;">
+      <a href="{{ '/' | url }}" aria-label="Democratic Justice home">
+        <img class="mark xl"
+             src="{{ '/images/three-dots-white.svg' | url }}"
+             alt="" aria-hidden="true"
+             loading="lazy" decoding="async"
+             style="position:absolute; bottom: var(--gap); right: 20px; opacity: 0.5;">
+      </a>
     </div>
   </footer>
 


### PR DESCRIPTION
## Summary
- Change footer three-dots icon from gold to white
- Link header and footer micro marks back to the front page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7a8e20f5c8330900e77db38cdc290