### PR TITLE
Add security headers to _headers

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,3 +1,7 @@
 /*
-  Content-Security-Policy: script-src 'self' https://www.googletagmanager.com
-
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://www.googletagmanager.com; object-src 'none'; base-uri 'self'
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Referrer-Policy: no-referrer
+  Permissions-Policy: geolocation=(), microphone=(), camera=()


### PR DESCRIPTION
## Summary
- enforce HSTS, CSP, and other security headers across all routes via Netlify `_headers`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7bc2141748330bc4169bd99e4a3a4