### PR TITLE
Add Dependabot config and npm audit workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -1,0 +1,16 @@
+name: NPM Audit
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install --package-lock-only
+      - run: npm audit --audit-level=high


### PR DESCRIPTION
## Summary
- enable weekly npm dependency checks via Dependabot
- add CI workflow running `npm audit --audit-level=high`

## Testing
- `npm install --package-lock-only`
- `npm audit --audit-level=high`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7bde62c84833087c60c30363e5d2c