### PR TITLE
Add analytics monitoring and backup workflow

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -49,6 +49,11 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addWatchTarget("./bundle.js");
   eleventyConfig.addWatchTarget("./ga-consent.js");
 
+  // ## GLOBALS ##
+  // Expose environment variables to templates so deployment-specific
+  // credentials (e.g. analytics tokens) can be referenced safely.
+  eleventyConfig.addNunjucksGlobal("env", process.env);
+
   // ## SERVER OPTIONS ##
   eleventyConfig.setServerOptions({
     showAllFiles: true

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,32 @@
+name: scheduled-backup
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    env:
+      S3_BUCKET: ${{ secrets.S3_BUCKET }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Archive repository
+        run: tar -czf repo-backup.tar.gz .
+
+      - name: Upload to S3
+        if: env.S3_BUCKET != ''
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: |
+          aws s3 cp repo-backup.tar.gz s3://$S3_BUCKET/$(date +%F)-repo-backup.tar.gz
+
+      - name: Store as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: repo-backup
+          path: repo-backup.tar.gz

--- a/_includes/layout.html
+++ b/_includes/layout.html
@@ -103,5 +103,10 @@
   <!-- Defer so it doesn't block rendering -->
   <script defer src="{{ '/bundle.js' | url }}"></script>
 
+  {%- if env.CLOUDFLARE_ANALYTICS_TOKEN -%}
+  <!-- Cloudflare Web Analytics -->
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "{{ env.CLOUDFLARE_ANALYTICS_TOKEN }}"}'></script>
+  {%- endif -%}
+
 </body>
 </html>

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,20 @@
+# Monitoring and Backups
+
+## Cloudflare Web Analytics
+1. Create a site in [Cloudflare Web Analytics](https://www.cloudflare.com/web-analytics/).
+2. Generate a beacon token and add it as the environment variable `CLOUDFLARE_ANALYTICS_TOKEN` in the deployment platform (e.g. Netlify).
+3. The site layout automatically injects the Cloudflare beacon when the token is present.
+
+## Alerts
+- In the Cloudflare dashboard open **Analytics → Alerts**.
+- Create notifications for request spikes or 5xx error rates according to your thresholds.
+- Configure recipients such as email or Slack to receive the alert.
+
+## Scheduled Backups
+- The workflow at `.github/workflows/backup.yml` archives this repository on a daily schedule.
+- Provide the following secrets so the workflow can upload the archive to external storage:
+  - `AWS_ACCESS_KEY_ID`
+  - `AWS_SECRET_ACCESS_KEY`
+  - `AWS_REGION`
+  - `S3_BUCKET`
+- Backups are uploaded to the specified S3 bucket and stored as workflow artifacts.


### PR DESCRIPTION
## Summary
- expose environment variables to templates for analytics token
- inject Cloudflare Web Analytics beacon if a token is provided
- schedule daily repository backups to external storage via GitHub Actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7c5e06f208330bd03ab7790c8bbb7