### PR TITLE
Add dark mode wordmark support

### DIFF
--- a/_includes/layout.html
+++ b/_includes/layout.html
@@ -43,9 +43,12 @@
       <div class="nav-inner">
         <div class="logo-wrap">
           <a href="{{ '/' | url }}" aria-label="Democratic Justice home">
-            <img class="wordmark"
-                 src="{{ '/images/wordmark-blue-on-white.svg' | url }}"
-                 alt="Democratic Justice">
+            <picture>
+              <source media="(prefers-color-scheme: dark)" srcset="{{ '/images/wordmark-white-on-blue.svg' | url }}">
+              <img class="wordmark"
+                   src="{{ '/images/wordmark-blue-on-white.svg' | url }}"
+                   alt="Democratic Justice">
+            </picture>
           </a>
         </div>
         <button class="nav-toggle" type="button" aria-expanded="false" aria-label="Menu" aria-controls="primary-nav">

--- a/style.css
+++ b/style.css
@@ -61,6 +61,8 @@
   border-bottom:1px solid color-mix(in srgb, var(--silver) 30%, transparent);
 }
 
+[data-theme="dark"] .wordmark{content:url('/images/wordmark-white-on-blue.svg')}
+
 
 /* Reset */
 *{box-sizing:border-box;margin:0;padding:0}


### PR DESCRIPTION
## Summary
- wrap header logo image in a `<picture>` element and add dark-mode `<source>`
- swap wordmark in dark theme via CSS `content` rule

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c80cc4eb588330ae75efa9fb09680b