### PR TITLE
Enhance dark theme surface contrast

### DIFF
--- a/style.css
+++ b/style.css
@@ -26,11 +26,11 @@
 
 [data-theme="dark"]{
   --brand:#3B82F6;
-  --paper-light:#F9FAFB;
+  --paper-light:#1F2937;
   --paper:#0F172A;
   --white:#F1F5F9;
   --gray-dark:#1F2937;
-  --text:#F1F5F9;
+  --text:#F9FAFB;
   --muted:#94A3B8;
   --gold:#FACC15;
   --silver:#374151;


### PR DESCRIPTION
## Summary
- Use #1F2937 for dark theme paper-light surfaces
- Lighten text color to #F9FAFB for contrast on dark backgrounds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c810b3b9448330aa517528e4cee84b