### PR TITLE
Ensure navigation visible on small screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -237,7 +237,6 @@ p{max-width:65ch;margin-bottom:16px}
 }
 @media (max-width:768px){
   .bottom-nav{display:flex;}
-  .nav{display:none;}
 }
 
 /* Theme toggle button */


### PR DESCRIPTION
## Summary
- Keep main navigation visible on viewports under 768px by removing the rule that hid `.nav`.

## Testing
- `npm test`
- `npm run build`
- `node check_nav.js` *(fails: Invalid file descriptor to ICU data received)*

------
https://chatgpt.com/codex/tasks/task_e_68c81cf574b483308df90f0449342294