### PR TITLE
Improve nav toggle icon and theming

### DIFF
--- a/_includes/layout.html
+++ b/_includes/layout.html
@@ -52,13 +52,9 @@
           </a>
         </div>
         <button class="nav-toggle" type="button" aria-expanded="false" aria-label="Menu" aria-controls="primary-nav">
-          <a href="{{ '/' | url }}" aria-label="Democratic Justice home">
-            <svg class="mark xl" aria-hidden="true" viewBox="0 0 9.45 8" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-              <path d="M4.28,5.47c0,.56-.45,1.01-1.01,1.01s-1.01-.45-1.01-1.01.45-1.01,1.01-1.01,1.01.45,1.01,1.01ZM5.77,2.43c0,.56-.45,1.01-1.01,1.01s-1.02-.45-1.02-1.01.45-1.01,1.02-1.01,1.01.45,1.01,1.01ZM7.27,5.5c0,.55-.45.99-1.01.99s-1.01-.44-1.01-.99.45-.99,1.01-.99,1.01.44,1.01.99Z"/>
-              <path d="M7.27,7.53h1.09V.48h-1.09v-.48h2.18v8h-2.18v-.47Z"/>
-              <path d="M2.18,7.53h-1.09V.48h1.09v-.48H0v8h2.18v-.47Z"/>
-            </svg>
-          </a>
+          <svg class="nav-toggle-icon" aria-hidden="true" viewBox="0 0 24 24">
+            <path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+          </svg>
         </button>
         <ul class="nav-links" id="primary-nav">
           <li><a href="{{ '/archive' | url }}">Proof</a></li>

--- a/style.css
+++ b/style.css
@@ -99,11 +99,18 @@ p{max-width:65ch;margin-bottom:16px}
 .nav{
   position:sticky;
   top:0;
+  --nav-toggle-color: var(--navy);
   background:var(--white);
   color:var(--brand);
   border-bottom:1px solid color-mix(in srgb, var(--silver) 30%, transparent);
   z-index:100;
   box-shadow:0 2px 8px rgba(15,39,66,.08);
+}
+
+.nav--navy{
+  background:var(--navy);
+  color:var(--white);
+  --nav-toggle-color: var(--white);
 }
 .nav-inner{
   display:flex;
@@ -174,7 +181,7 @@ p{max-width:65ch;margin-bottom:16px}
   cursor:pointer;
   min-width:44px;
   min-height:44px;
-  color:var(--navy);
+  color:var(--nav-toggle-color);
   align-items:center;
   justify-content:center;
 }


### PR DESCRIPTION
## Summary
- replace nested link + dots icon with direct SVG hamburger in nav toggle
- introduce `--nav-toggle-color` variable and `nav--navy` class for contrasting toggle colors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c81fa79c9c83308e695417ba356d8e