### PR TITLE
Use lighter hero background on small screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -268,6 +268,13 @@ p{max-width:65ch;margin-bottom:16px}
   position: relative;
 }
 
+@media (max-width:768px){
+  .hero{
+    background-color: var(--white);
+    color: var(--text);
+  }
+}
+
 /* Hero grid */
 .hero-grid{
   display: grid;


### PR DESCRIPTION
## Summary
- Lighten hero section background on screens narrower than 768px.
- Ensure text color switches to standard body color for readability.

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c82604d0e08330899cf5d5ecccf71d