### PR TITLE
Add fallback social share image

### DIFF
--- a/_data/site.json
+++ b/_data/site.json
@@ -1,4 +1,5 @@
 {
   "url": "https://democraticjustice.org",
-  "mobileNavBreakpoint": 768
+  "mobileNavBreakpoint": 768,
+  "defaultImage": "/images/wordmark-white-on-blue.svg"
 }

--- a/_includes/layout.html
+++ b/_includes/layout.html
@@ -8,11 +8,14 @@
   <meta name="description" content="{{ description | default: '' }}">
   <meta property="og:title" content="{{ title }}">
   <meta property="og:description" content="{{ description | default: '' }}">
-  {% if ogImage %}<meta property="og:image" content="{{ ogImage }}">{% endif %}
+  {% assign fallbackImage = site.url | append: site.defaultImage %}
+  {% assign resolvedOgImage = ogImage | default: fallbackImage %}
+  {% assign resolvedTwitterImage = twitterImage | default: fallbackImage %}
+  <meta property="og:image" content="{{ resolvedOgImage }}">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="{{ title }}">
   <meta name="twitter:description" content="{{ description | default: '' }}">
-  {% if twitterImage %}<meta name="twitter:image" content="{{ twitterImage }}">{% endif %}
+  <meta name="twitter:image" content="{{ resolvedTwitterImage }}">
 
   <meta name="theme-color" content="#0F2742">
 


### PR DESCRIPTION
## Summary
- add a default social share image path to the global site data
- ensure the layout always outputs that fallback for Open Graph and Twitter images

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c874910d188330819be19ac3c03bcf