### PR TITLE
Generate share image PNGs during Eleventy build

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,37 @@
 // .eleventy.js
 const { DateTime } = require("luxon");
+const Image = require("@11ty/eleventy-img");
+const fs = require("node:fs/promises");
+const path = require("node:path");
+
+async function generateSharePNGs() {
+  const shareOutputDir = path.join("_site", "share");
+
+  let entries;
+  try {
+    entries = await fs.readdir(shareOutputDir, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+
+  const svgFiles = entries.filter((entry) => entry.isFile() && entry.name.endsWith(".svg"));
+
+  for (const svgFile of svgFiles) {
+    const sourcePath = path.join(shareOutputDir, svgFile.name);
+    await Image(sourcePath, {
+      formats: ["png"],
+      widths: [null],
+      outputDir: shareOutputDir,
+      filenameFormat: function (id, src, width, format) {
+        const basename = path.basename(src, path.extname(src));
+        return `${basename}.${format}`;
+      }
+    });
+  }
+}
 
 module.exports = function(eleventyConfig) {
   // ## COLLECTIONS ##
@@ -57,6 +89,10 @@ module.exports = function(eleventyConfig) {
   // ## SERVER OPTIONS ##
   eleventyConfig.setServerOptions({
     showAllFiles: true
+  });
+
+  eleventyConfig.on("afterBuild", async () => {
+    await generateSharePNGs();
   });
 
   // ## DIRECTORY CONFIG ##

--- a/case.njk
+++ b/case.njk
@@ -8,8 +8,8 @@ permalink: "proofs/{{ (proof.slug or proof.case_id) | slug }}/index.html"
 eleventyComputed:
   title: "{{ proof.title }}"
   description: "{{ proof.thesis }}"
-  ogImage: "https://democraticjustice.org/share/{{ (proof.slug or proof.case_id) | slug }}-facebook.svg"
-  twitterImage: "https://democraticjustice.org/share/{{ (proof.slug or proof.case_id) | slug }}-twitter.svg"
+  ogImage: "https://democraticjustice.org/share/{{ (proof.slug or proof.case_id) | slug }}-facebook.png"
+  twitterImage: "https://democraticjustice.org/share/{{ (proof.slug or proof.case_id) | slug }}-twitter.png"
   instagramImage: "https://democraticjustice.org/share/{{ (proof.slug or proof.case_id) | slug }}-instagram.svg"
 ---
 <style>

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@11ty/eleventy": "^3.1.2"
+    "@11ty/eleventy": "^3.1.2",
+    "@11ty/eleventy-img": "^6.0.4"
   },
   "devDependencies": {
     "luxon": "^3.7.2",


### PR DESCRIPTION
## Summary
- add an Eleventy afterBuild hook that converts generated share SVGs into PNGs with `@11ty/eleventy-img`
- add the image plugin dependency required to produce the PNG assets at build time
- update proof page metadata to reference the PNG share images for improved social previews

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c874ae577c833080dd340d471957a3