### PR TITLE
Use theme surfaces for light backgrounds

### DIFF
--- a/style.css
+++ b/style.css
@@ -155,6 +155,36 @@
   border-color:var(--silver);
 }
 
+[data-theme="dark"] .proof-box,
+[data-theme="dark"] .method-single-box,
+[data-theme="dark"] .action,
+[data-theme="dark"] .action-card,
+[data-theme="dark"] .modal__card,
+[data-theme="dark"] .modal-content,
+[data-theme="dark"] .action-shortcuts a,
+[data-theme="dark"] #about-page .context-note,
+[data-theme="dark"] .offense-card,
+[data-theme="dark"] .logic-step,
+[data-theme="dark"] .view-toggle-btn,
+[data-theme="dark"] .timeline-content{
+  color:var(--text);
+}
+
+[data-theme="dark"] .action-card,
+[data-theme="dark"] .action-shortcuts a,
+[data-theme="dark"] .timeline-content,
+[data-theme="dark"] .offense-card,
+[data-theme="dark"] .logic-step,
+[data-theme="dark"] .modal__card,
+[data-theme="dark"] .modal-content{
+  border-color:var(--border-strong);
+}
+
+[data-theme="dark"] #about-page .context-note{
+  border-color:var(--border-strong);
+  border-left-color:var(--brand);
+}
+
 [data-theme="dark"] .nav{
   background:var(--gray-dark);
   color:var(--brand);
@@ -200,7 +230,7 @@ p{max-width:65ch;margin-bottom:16px}
   position:sticky;
   top:0;
   --nav-toggle-color: var(--navy);
-  background:var(--white);
+  background:var(--paper-light);
   color:var(--brand);
   border-bottom:1px solid color-mix(in srgb, var(--silver) 30%, transparent);
   z-index:100;
@@ -226,7 +256,7 @@ p{max-width:65ch;margin-bottom:16px}
   top:100%;
   left:0;
   right:0;
-  background:var(--white);
+  background:var(--paper-light);
   padding:16px 20px;
   gap:12px;
   box-shadow:0 4px 8px rgba(0,0,0,.1);
@@ -370,7 +400,7 @@ p{max-width:65ch;margin-bottom:16px}
 
 @media (max-width:768px){
   .hero{
-    background-color: var(--white);
+    background-color: var(--paper-light);
     color: var(--text);
   }
 }
@@ -438,8 +468,8 @@ p{max-width:65ch;margin-bottom:16px}
 
 /* Proof Box */
 .proof-box{
-  background:var(--white);
-  color:var(--navy);
+  background:var(--paper-light);
+  color:var(--text);
   border-radius:12px;
   overflow:hidden;
   box-shadow:0 0 0 3px rgba(255,255,255,0.1), 0 14px 32px rgba(0,0,0,.25);
@@ -473,7 +503,7 @@ p{max-width:65ch;margin-bottom:16px}
   margin-bottom:12px;
 }
 .proof-box__meta{
-  color:var(--navy);
+  color:var(--text-muted);
   font-size:14px;
   margin-bottom:16px;
 }
@@ -517,7 +547,7 @@ p{max-width:65ch;margin-bottom:16px}
   margin-top:var(--gap);
 }
 .case-card{
-  background:var(--white);
+  background:var(--paper-light);
   border:1px solid color-mix(in srgb, var(--silver) 30%, transparent);
   border-left:4px solid var(--navy);
   border-radius:10px;
@@ -530,7 +560,7 @@ p{max-width:65ch;margin-bottom:16px}
   box-shadow:0 4px 12px rgba(15,39,66,.15);
 }
 [data-theme="dark"] .case-card{
-  background:var(--gray-dark);
+  background:var(--paper-light);
   color:var(--text);
   border-color:var(--silver);
 }
@@ -538,7 +568,7 @@ p{max-width:65ch;margin-bottom:16px}
   color:var(--text);
 }
 .case-card h3 a:hover{
-  color:var(--navy);
+  color:var(--brand);
 }
 .case-meta{
   font-size:13px;
@@ -583,7 +613,7 @@ p{max-width:65ch;margin-bottom:16px}
 }
 .method-single-box {
   margin-top: 40px;
-  background-color: var(--white);
+  background-color: var(--paper-light);
   border-radius: 12px;
   overflow: hidden;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
@@ -616,7 +646,7 @@ p{max-width:65ch;margin-bottom:16px}
   font-size: 20px;
   font-weight: 700;
   text-transform: uppercase;
-  color: var(--navy);
+  color: var(--brand);
   margin-bottom: 4px;
 }
 .method-step-description {
@@ -628,11 +658,11 @@ p{max-width:65ch;margin-bottom:16px}
 /* Action Section */
 .action{
   padding:var(--section-gap) 0;
-  background:var(--white);
+  background:var(--paper-light);
   border-top:1px solid color-mix(in srgb, var(--silver) 30%, transparent);
 }
 .action-card{
-  background:var(--white);
+  background:var(--paper-light);
   border:1px solid color-mix(in srgb, var(--silver) 30%, transparent);
   border-radius:10px;
   padding:24px;
@@ -764,7 +794,7 @@ p{max-width:65ch;margin-bottom:16px}
   background:rgba(10,49,97,.6);
 }
 .modal__card{
-  background:var(--white);
+  background:var(--paper-light);
   border:1px solid var(--navy);
   border-radius:12px;
   max-width:480px;
@@ -837,8 +867,15 @@ p{max-width:65ch;margin-bottom:16px}
   font-family: inherit;
   -webkit-appearance: none; /* For older Safari/Chrome */
   appearance: none;         /* Modern standard */
-  background: var(--white) url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%230F2742%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E') no-repeat right 16px center;
+  background: var(--paper-light) url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%230F2742%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E') no-repeat right 16px center;
   background-size: 10px;
+}
+
+[data-theme="dark"] .search-filter-controls select {
+  background: var(--paper-light) url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23E2E8F0%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E') no-repeat right 16px center;
+  background-size: 10px;
+  color: var(--text);
+  border-color: var(--border-strong);
 }
 .btn-reset {
   padding: 12px 16px;
@@ -958,23 +995,23 @@ html { scroll-behavior: smooth; }
   text-decoration: none;
   line-height: 1.2;
   min-height: 44px;
-  color: var(--navy);
-  background: var(--white);
+  color: var(--text);
+  background: var(--paper-light);
 }
 .action-shortcuts a:focus-visible {
   outline: 3px solid var(--navy);
   outline-offset: 2px;
 }
 .action-shortcuts a.is-active {
-  border-color: var(--navy);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--navy) 15%, transparent) inset;
+  border-color: var(--brand);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--brand) 25%, transparent) inset;
   font-weight: 700;
 }
 
 /* Tables */
 .key-info-table { width: 100%; border-collapse: collapse; margin: 10px 0 16px; font-size: 15px; }
 .key-info-table td { border: 1px solid var(--silver); padding: 10px 12px; vertical-align: top; }
-.key-info-table td:first-child { width: 180px; font-weight: 700; color: var(--navy); }
+.key-info-table td:first-child { width: 180px; font-weight: 700; color: var(--text); }
 
 /* Subtle highlight when jumping to a section */
 .action-item:target { outline: 2px solid rgba(16,89,168,.25); outline-offset: 6px; }
@@ -1004,7 +1041,7 @@ html { scroll-behavior: smooth; }
 }
 #about-page .signature { height: 36px; width: auto; display: block; }
 #about-page .sig-meta { display: inline-flex; gap: 8px; color: var(--text-muted); }
-#about-page .sig-name { font-weight: 700; color: var(--navy); }
+#about-page .sig-name { font-weight: 700; color: var(--text); }
 #about-page .sig-role { font-style: italic; }
 
 /* Print: keep it compact and neutral */
@@ -1015,7 +1052,7 @@ html { scroll-behavior: smooth; }
 /* === About: Hobbes context callout === */
 #about-page .context-note {
   display: block !important; /* Force visibility */
-  background: var(--white);
+  background: var(--paper-light);
   border: 1px solid var(--silver);
   border-left: 4px solid var(--navy);
   border-radius: 10px;
@@ -1031,7 +1068,7 @@ html { scroll-behavior: smooth; }
   margin: 0 0 6px;
   font-size: clamp(18px, 2.6vw, 20px);
   letter-spacing: .5px;
-  color: var(--navy);
+  color: var(--text);
 }
 
 #about-page .context-note p {
@@ -1042,12 +1079,12 @@ html { scroll-behavior: smooth; }
 /* Dark mode */
 @media (prefers-color-scheme: dark) {
   #about-page .context-note {
-    background: var(--navy);
-    border-color: var(--border-inverse);
-    border-left-color: var(--navy-light);
+    background: var(--paper-light);
+    border-color: var(--border-strong);
+    border-left-color: var(--brand);
   }
-  #about-page .context-note h3 { color: var(--border-subtle); }
-  #about-page .context-note p { color: var(--border-strong); }
+  #about-page .context-note h3 { color: var(--text); }
+  #about-page .context-note p { color: var(--text-soft); }
 }
 
 @media print {
@@ -1155,7 +1192,7 @@ html { scroll-behavior: smooth; }
   border: 1px solid var(--silver);
   border-radius: 12px;
   padding: 1.5rem;
-  background-color: var(--white);
+  background-color: var(--paper-light);
   box-shadow: 0 4px 6px rgba(10, 37, 64, 0.04);
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
   display: flex;
@@ -1177,7 +1214,7 @@ html { scroll-behavior: smooth; }
   height: 100%;
 }
 .action-card h3 {
-  color: var(--navy);
+  color: var(--text);
   margin-bottom: 0.5rem;
 }
 .action-card p {
@@ -1206,9 +1243,9 @@ html { scroll-behavior: smooth; }
   border-color: var(--brand);
 }
 .btn-navy:hover {
-  background: var(--white);
-  color: var(--navy);
-  border-color: var(--white);
+  background: var(--paper-light);
+  color: var(--text);
+  border-color: var(--paper-light);
 }
 
 /* COMPLETE MODAL STYLES */
@@ -1229,7 +1266,7 @@ html { scroll-behavior: smooth; }
   pointer-events: auto;
 }
 .modal-content {
-  background: var(--white);
+  background: var(--paper-light);
   border-radius: 12px;
   max-width: 650px;
   width: 90%;
@@ -1254,17 +1291,17 @@ html { scroll-behavior: smooth; }
   border: none;
 }
 .modal-close:hover {
-  color: var(--navy);
+  color: var(--text);
 }
 .modal-content h3 {
-  color: var(--navy);
+  color: var(--text);
   border-bottom: 1px solid var(--silver);
   padding-bottom: 0.5rem;
   margin-bottom: 1.5rem;
 }
 .key-info-list dt {
   font-weight: 700;
-  color: var(--navy);
+  color: var(--text);
   margin-top: 1rem;
 }
 .key-info-list dd {
@@ -1295,7 +1332,7 @@ html { scroll-behavior: smooth; }
   position: relative;                     /* so the X positions correctly */
   display: flex; flex-direction: column;
   width: 90%; max-width: 700px; max-height: 90vh;
-  background: var(--paper);
+  background: var(--paper-light);
   color: var(--text);
   border-radius: 12px;
   overflow: hidden;
@@ -1426,8 +1463,8 @@ html { scroll-behavior: smooth; }
   border: 1.5px solid currentColor;
 }
 .btn--on-dark{
-  background:var(--white); color: var(--navy);
-  border-color:var(--white);
+  background:var(--paper-light); color: var(--text);
+  border-color:var(--paper-light);
 }
 .btn--on-dark:hover{ filter: brightness(.96); }
 
@@ -1557,7 +1594,7 @@ html { scroll-behavior: smooth; }
 #proof-page .align-container{ max-width:1100px; margin:0 auto; padding:0 32px; }
 
 .doc{
-  background:var(--white);
+  background:var(--paper-light);
   color: var(--text);
   border:1px solid var(--border-subtle);
   border-radius:12px;
@@ -1568,7 +1605,7 @@ html { scroll-behavior: smooth; }
 /* Header (no blue slab) */
 .doc-header{ margin-bottom:18px; }
 .doc-row{ display:flex; align-items:center; justify-content:space-between; gap:16px; }
-.doc-mark{ display:inline-flex; align-items:center; gap:8px; font-weight:700; color:var(--navy); }
+.doc-mark{ display:inline-flex; align-items:center; gap:8px; font-weight:700; color:var(--text); }
 .doc-mark img{ width:14px; height:14px; filter:brightness(0) invert(0); }
 .doc-meta{ color:var(--text-muted); font-size:.95rem; display:flex; gap:6px; flex-wrap:wrap; }
 .doc-title{ margin:6px 0 4px; font-size: clamp(26px,3.2vw,38px); line-height:1.12; }
@@ -1578,7 +1615,7 @@ html { scroll-behavior: smooth; }
 /* Axioms */
 .axioms{ margin:18px 0 8px; }
 .axiom-grid{ list-style:none; padding:0; margin:0; display:grid; grid-template-columns:1fr; gap:16px; }
-.axiom-card{ background:var(--white); border:1px solid var(--border-subtle); border-radius:10px; padding:14px 14px 12px; position:relative; }
+.axiom-card{ background:var(--paper-light); border:1px solid var(--border-subtle); border-radius:10px; padding:14px 14px 12px; position:relative; }
 .axiom-bar{ position:absolute; left:0; right:0; bottom:-5px; height:5px; background:var(--border-soft); border-radius:0 0 10px 10px; }
 .axiom-title{ margin:0 0 6px; font-weight:700; }
 .axiom-cite{ margin:0; font-size:.9rem; color:var(--text-subtle); }
@@ -1587,7 +1624,7 @@ html { scroll-behavior: smooth; }
 /* Evidence chain */
 .evidence-chain h2{ margin:18px 0 10px; }
 .chain{ list-style:none; padding:0; margin:0; display:grid; grid-template-columns:1fr; gap:16px; }
-.chain-step{ border:1px solid var(--border-subtle); border-radius:10px; padding:12px; background:var(--white); }
+.chain-step{ border:1px solid var(--border-subtle); border-radius:10px; padding:12px; background:var(--paper-light); }
 .chain-step__head{ display:flex; align-items:center; gap:10px; margin-bottom:6px; }
 .chain-step__num{ width:26px; height:26px; border-radius:7px; display:grid; place-items:center; background:var(--brand); color:var(--white); font-weight:700; font-size:.9rem; }
 .chain-step__title{ margin:0; font-weight:700; }
@@ -1604,7 +1641,7 @@ html { scroll-behavior: smooth; }
 /* Reveal */
 .reveal h2{ margin:18px 0 10px; }
 .split{ display:grid; grid-template-columns:1fr; gap:16px; }
-.split__pane{ border:1px solid var(--border-subtle); border-radius:10px; padding:14px; background:var(--white); }
+.split__pane{ border:1px solid var(--border-subtle); border-radius:10px; padding:14px; background:var(--paper-light); }
 .split__pane--actual h3{ color:var(--danger-strong); }
 
 /* Conclusion */
@@ -1708,7 +1745,7 @@ html { scroll-behavior: smooth; }
 #proof-page .doc {
   margin: 40px auto;
   max-width: 900px;
-  background: var(--white);
+  background: var(--paper-light);
   border: 3px solid var(--ink-strong);
   border-radius: 16px;
   overflow: hidden;
@@ -1846,7 +1883,7 @@ html { scroll-behavior: smooth; }
 }
 
 .offense-card {
-  background: var(--white);
+  background: var(--paper-light);
   border: 3px solid var(--border-subtle);
   border-radius: 12px;
   padding: 24px 24px 24px 48px;
@@ -1902,7 +1939,7 @@ html { scroll-behavior: smooth; }
 }
 
 .logic-step {
-  background: var(--white);
+  background: var(--paper-light);
   border: 2px solid var(--border-subtle);
   border-radius: 12px;
   padding: 20px 24px 20px 60px;
@@ -2096,7 +2133,7 @@ html { scroll-behavior: smooth; }
 }
 
 .view-toggle-btn {
-    background: var(--white);
+    background: var(--paper-light);
     border: 2px solid var(--brand);
     color: var(--brand);
     padding: 10px 20px;
@@ -2122,7 +2159,7 @@ html { scroll-behavior: smooth; }
 
 .timeline-month-header {
     font-size: 24px;
-    color: var(--navy);
+    color: var(--text);
     border-bottom: 2px solid var(--brand);
     padding-bottom: 8px;
     margin-bottom: 20px;
@@ -2154,7 +2191,7 @@ html { scroll-behavior: smooth; }
 
 .timeline-content {
     flex: 1;
-    background: var(--white);
+    background: var(--paper-light);
     border: 1px solid var(--silver);
     border-radius: 8px;
     padding: 16px;
@@ -2175,7 +2212,7 @@ html { scroll-behavior: smooth; }
 }
 
 .timeline-content h4 a {
-    color: var(--navy);
+    color: var(--text);
     text-decoration: none;
 }
 
@@ -2254,7 +2291,7 @@ html { scroll-behavior: smooth; }
   text-transform: uppercase;
   font-size: 16px;
   letter-spacing: 0.5px;
-  color: var(--navy);
+  color: var(--text);
   min-width: auto;
 }
 .proof-summary-text {
@@ -2306,7 +2343,7 @@ html { scroll-behavior: smooth; }
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  color: var(--navy);
+  color: var(--text);
 }
 .proof-strength-bars {
   display: flex;
@@ -2414,7 +2451,7 @@ html { scroll-behavior: smooth; }
 }
 .citation-btn {
   padding: 8px 16px;
-  background: var(--white);
+  background: var(--paper-light);
   border: 1px solid var(--silver);
   border-radius: 6px;
   cursor: pointer;
@@ -2426,7 +2463,7 @@ html { scroll-behavior: smooth; }
   border-color: var(--brand);
 }
 .citation-output {
-  background: var(--white);
+  background: var(--paper-light);
   border: 1px solid var(--silver);
   border-radius: 6px;
   padding: 16px;
@@ -2451,7 +2488,7 @@ html { scroll-behavior: smooth; }
 }
 .share-btn {
   padding: 12px;
-  background: var(--white);
+  background: var(--paper-light);
   border: 1px solid var(--silver);
   border-radius: 6px;
   cursor: pointer;
@@ -2508,7 +2545,7 @@ html { scroll-behavior: smooth; }
   align-items: center;
   justify-content: center;
   border-radius: 50%;
-  background: var(--white);
+  background: var(--paper-light);
   border: 1px solid var(--silver);
   color: var(--brand);
   cursor: pointer;


### PR DESCRIPTION
## Summary
- replace hard-coded white backgrounds on cards, actions, modals, and timeline elements with theme surface variables
- tune supporting typography and accents for readability across light and dark modes, including proof boxes, timeline headers, and summary labels
- update context note and select controls to use dark-mode aware assets and add targeted `[data-theme="dark"]` overrides

## Testing
- `npm run test:dark` *(fails: Playwright/@playwright/test not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d490bee88330896684680e382828