### PR TITLE
Add canonical links, structured data, breadcrumbs, and integrity page

### DIFF
--- a/_includes/layout.html
+++ b/_includes/layout.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <link rel="canonical" href="{{ site.url }}{{ page.url | url }}" />
 
   <title>{{ title }}</title>
   <meta name="description" content="{{ description | default: '' }}">
@@ -35,6 +36,30 @@
   <!-- Root-relative assets (safe from any page depth and pathPrefix-aware) -->
   <link rel="icon" href="{{ '/images/three-dots-blue.svg' | url }}" type="image/svg+xml">
   <link rel="stylesheet" href="{{ '/style.css' | url }}">
+
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "Organization",
+          "name": "Democratic Justice",
+          "url": "https://democraticjustice.org",
+          "logo": "https://democraticjustice.org/images/wordmark-blue-on-white.svg"
+        },
+        {
+          "@type": "WebSite",
+          "url": "https://democraticjustice.org",
+          "name": "Democratic Justice",
+          "potentialAction": {
+            "@type": "SearchAction",
+            "target": "https://democraticjustice.org/search?q={search_term_string}",
+            "query-input": "required name=search_term_string"
+          }
+        }
+      ]
+    }
+  </script>
 
 </head>
 <body>
@@ -89,6 +114,7 @@
       <p><strong>Proof. Not Spin.</strong></p>
       <p>A 100% volunteer-run project. We do not solicit or accept financial contributions. We do not endorse candidates.</p>
       <p><a href="mailto:setho@democraticjustice.org">Submit Proof Confidentially</a></p>
+      <p><a href="{{ '/integrity' | url }}">Proof of Integrity</a></p>
       <p><a href="{{ '/privacy' | url }}">Privacy Policy</a></p>
 
       <a href="{{ '/' | url }}" aria-label="Democratic Justice home">

--- a/case.njk
+++ b/case.njk
@@ -28,6 +28,39 @@ eleventyComputed:
 
 <div class="align-container" id="proof-page">
   <article class="doc">
+    <nav aria-label="Breadcrumb" class="breadcrumb">
+      <ol>
+        <li><a href="{{ '/' | url }}">Home</a></li>
+        <li><a href="{{ '/archive' | url }}">Proof</a></li>
+        <li aria-current="page">{{ proof.title }}</li>
+      </ol>
+    </nav>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "{{ site.url }}"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Proof",
+            "item": "{{ site.url }}{{ '/archive/' | url }}"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "{{ proof.title }}",
+            "item": "{{ site.url }}{{ page.url | url }}"
+          }
+        ]
+      }
+    </script>
     <header class="doc-header">
       <div class="doc-row">
         <div class="doc-mark">

--- a/integrity.njk
+++ b/integrity.njk
@@ -1,0 +1,16 @@
+---
+layout: layout.html
+title: "Proof of Integrity — Democratic Justice"
+description: "We do not solicit or accept financial contributions and we do not endorse candidates."
+permalink: /integrity/
+---
+
+<section class="content-page" id="integrity-page">
+  <div class="align-container">
+    <h1>Proof of Integrity</h1>
+    <p>We do not solicit or accept financial contributions.</p>
+    <p>We do not endorse candidates.</p>
+    <p>Democratic Justice is a 100% volunteer-run project dedicated to objective evidence. These principles ensure our work remains independent and trustworthy.</p>
+  </div>
+</section>
+


### PR DESCRIPTION
## Summary
- add canonical link tags and organization/website structured data in the site layout
- implement breadcrumb navigation with JSON-LD on proof pages
- create a Proof of Integrity page and link it from the footer

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist; host dependencies missing)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c8d92ee9a083308fea2c40d97b639d