### PR TITLE
Ensure nav toggle icon styling works across browsers

### DIFF
--- a/_includes/layout.html
+++ b/_includes/layout.html
@@ -80,8 +80,8 @@
           </a>
         </div>
         <button class="nav-toggle" type="button" aria-expanded="false" aria-label="Menu" aria-controls="primary-nav">
-          <svg class="nav-toggle-icon" aria-hidden="true" viewBox="0 0 24 24">
-            <path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+          <svg class="nav-toggle-icon" aria-hidden="true" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+            <path d="M3 6h18M3 12h18M3 18h18" stroke-width="2" stroke-linecap="round"/>
           </svg>
         </button>
         <ul class="nav-links" id="primary-nav">

--- a/style.css
+++ b/style.css
@@ -316,6 +316,12 @@ p{max-width:65ch;margin-bottom:16px}
   justify-content:center;
 }
 
+.nav-toggle-icon{
+  width:24px;
+  height:24px;
+  stroke:var(--nav-toggle-color);
+}
+
 @media (min-width:769px){
   .nav-links{
     display:flex;


### PR DESCRIPTION
## Summary
- add explicit size and fill/stroke attributes to the navigation toggle SVG icon
- add a `.nav-toggle-icon` style so the stroke color follows the CSS custom property across browsers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c97aa8bfe88330b882203fcf4de261