### PR TITLE
Normalize proofs data for Eleventy templates

### DIFF
--- a/case.njk
+++ b/case.njk
@@ -1,7 +1,7 @@
 ---
 layout: "layout.html"
 pagination:
-  data: proofs
+  data: collections.sortedProofs
   size: 1
   alias: proof
 permalink: "proofs/{{ (proof.umbrella_category | slug) }}/{{ (proof.slug or proof.case_id) | slug }}/index.html"


### PR DESCRIPTION
## Summary
- normalize `_data/proofs.json` when building the sorted proofs collection to handle nested data structures
- update proof pagination to use the normalized collection so Eleventy page templates receive the correct entries

## Testing
- npx eleventy

------
https://chatgpt.com/codex/tasks/task_e_68ca1f1bfaa88330ab82dba313252250