### PR TITLE
Add hero headline micro mark background

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -11,7 +11,7 @@ description: Proof. Not spin. Democratic Justice equips West Virginia Democrats 
   <div class="align-container">
     <div class="hero-grid">
       <div>
-        <h1>Proof.<strong>Not Spin.</strong></h1>
+        <h1 class="hero-headline">Proof.<strong>Not Spin.</strong></h1>
         <div class="btn-group">
           <a href="{{ '/archive' | url }}" class="btn btn-accent">
             See the Proof

--- a/style.css
+++ b/style.css
@@ -404,10 +404,33 @@ p{max-width:65ch;margin-bottom:16px}
   position: relative;
 }
 
+.hero-headline{
+  position: relative;
+  display: inline-block;
+  z-index: 1;
+}
+
+.hero-headline::after{
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -56%);
+  width: min(65vw, 520px);
+  aspect-ratio: 1 / 1;
+  background: url('images/three-dots-white.svg') no-repeat center/contain;
+  opacity: 0.1;
+  pointer-events: none;
+  z-index: -1;
+}
+
 @media (max-width:768px){
   .hero{
     background-color: var(--paper-light);
     color: var(--text);
+  }
+  .hero-headline::after{
+    content: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated class to the hero headline so it can host decorative artwork
- render a large translucent white micro mark behind the hero headline on larger viewports while keeping mobile styling unchanged

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca2a89bf788330bef543ac87edc955