### PR TITLE
Adjust pre-check checklist dark theme colors

### DIFF
--- a/style.css
+++ b/style.css
@@ -1302,6 +1302,16 @@ html { scroll-behavior: smooth; }
   color: var(--brand);
 }
 
+[data-theme="dark"] .pre-check-box {
+  background: var(--surface-soft);
+  border-color: var(--surface-soft);
+  border-left-color: var(--brand);
+}
+[data-theme="dark"] .pre-check-box p,
+[data-theme="dark"] .pre-check-box li {
+  color: var(--text);
+}
+
 /* Step-by-Step Section Styling */
 .action-step {
   text-align: center;


### PR DESCRIPTION
## Summary
- lighten the pre-action checklist container in dark mode while preserving the brand-colored accent border
- reset paragraph and list item text colors in the checklist so dark theme content stays legible

## Testing
- not run (CSS change only)


------
https://chatgpt.com/codex/tasks/task_e_68cac91990688330bc190bcbc80f04ee