### PR TITLE
Adjust dark theme outline blue button contrast

### DIFF
--- a/style.css
+++ b/style.css
@@ -488,6 +488,15 @@ p{max-width:65ch;margin-bottom:16px}
   background:var(--navy);
   color:var(--white);
 }
+[data-theme="dark"] .btn-outline-blue{
+  color:var(--text);
+  border-color:var(--border-contrast);
+}
+[data-theme="dark"] .btn-outline-blue:hover{
+  background:var(--text);
+  color:var(--navy);
+  border-color:var(--text);
+}
 .btn-group{
   display:flex;
   gap:16px;


### PR DESCRIPTION
## Summary
- adjust the dark theme outline-blue button to use light text and border values for contrast
- invert the hover treatment in dark mode so the button remains legible when focused or hovered

## Testing
- npm run test:dark *(fails: host system is missing Playwright browser dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68cad283678c8330b87150afb8f2b6dc