### PR TITLE
Improve breadcrumb styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -2744,3 +2744,33 @@ html { scroll-behavior: smooth; }
   width: 20px;
   height: 20px;
 }
+.breadcrumb {
+  margin-bottom: 1.5rem;
+}
+
+.breadcrumb ol {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.breadcrumb li {
+  display: flex;
+  align-items: center;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.breadcrumb li[aria-current="page"] {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.breadcrumb li + li::before {
+  content: "/";
+  color: var(--text-muted);
+  margin-right: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- display breadcrumb lists as flex rows without default numbering
- emphasize the current page item and insert separators between breadcrumb links

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc6d1e5f64833086c91804562ef325