### PR TITLE
Fix modal focus trap event binding

### DIFF
--- a/script.js
+++ b/script.js
@@ -213,29 +213,36 @@ export function initNavigation() {
             this.firstFocusable = null;
             this.lastFocusable = null;
             this.active = false;
+            this.boundKeyHandler = null;
         }
-        
+
         activate() {
             if (this.active) return;
-            
+
             this.focusableElements = this.element.querySelectorAll(
                 'a[href], button, textarea, input[type="text"], input[type="radio"], input[type="checkbox"], select, [tabindex]:not([tabindex="-1"])'
             );
-            
+
             this.firstFocusable = this.focusableElements[0];
             this.lastFocusable = this.focusableElements[this.focusableElements.length - 1];
-            
-            this.element.addEventListener('keydown', this.handleKeyDown.bind(this));
+
+            if (!this.boundKeyHandler) {
+                this.boundKeyHandler = this.handleKeyDown.bind(this);
+            }
+
+            this.element.addEventListener('keydown', this.boundKeyHandler);
             this.firstFocusable?.focus();
             this.active = true;
-            
+
             // Store last focused element
             this.lastFocus = document.activeElement;
         }
-        
+
         deactivate() {
             if (!this.active) return;
-            this.element.removeEventListener('keydown', this.handleKeyDown.bind(this));
+            if (this.boundKeyHandler) {
+                this.element.removeEventListener('keydown', this.boundKeyHandler);
+            }
             this.lastFocus?.focus();
             this.active = false;
         }

--- a/src/navigation.js
+++ b/src/navigation.js
@@ -190,29 +190,36 @@ export function initNavigation() {
             this.firstFocusable = null;
             this.lastFocusable = null;
             this.active = false;
+            this.boundKeyHandler = null;
         }
-        
+
         activate() {
             if (this.active) return;
-            
+
             this.focusableElements = this.element.querySelectorAll(
                 'a[href], button, textarea, input[type="text"], input[type="radio"], input[type="checkbox"], select, [tabindex]:not([tabindex="-1"])'
             );
-            
+
             this.firstFocusable = this.focusableElements[0];
             this.lastFocusable = this.focusableElements[this.focusableElements.length - 1];
-            
-            this.element.addEventListener('keydown', this.handleKeyDown.bind(this));
+
+            if (!this.boundKeyHandler) {
+                this.boundKeyHandler = this.handleKeyDown.bind(this);
+            }
+
+            this.element.addEventListener('keydown', this.boundKeyHandler);
             this.firstFocusable?.focus();
             this.active = true;
-            
+
             // Store last focused element
             this.lastFocus = document.activeElement;
         }
-        
+
         deactivate() {
             if (!this.active) return;
-            this.element.removeEventListener('keydown', this.handleKeyDown.bind(this));
+            if (this.boundKeyHandler) {
+                this.element.removeEventListener('keydown', this.boundKeyHandler);
+            }
             this.lastFocus?.focus();
             this.active = false;
         }


### PR DESCRIPTION
## Summary
- store the modal focus trap keydown handler the first time it is bound in the navigation module so the same function is reused when adding/removing listeners
- mirror the same bound-handler fix in the legacy script version to keep both copies aligned

## Testing
- Manual Playwright modal regression script exercising repeated open/close cycles

------
https://chatgpt.com/codex/tasks/task_e_68cc7a28fe8883309ff858b431a8a7d9