### PR TITLE
Display violation consequences in brief pages

### DIFF
--- a/_data/briefs.json
+++ b/_data/briefs.json
@@ -215,4 +215,3 @@
     "nextBrief": null
   }
 ]
-```

--- a/brief.njk
+++ b/brief.njk
@@ -31,6 +31,9 @@ eleventyComputed:
         {% if violation.summary %}
         <p>{{ violation.summary }}</p>
         {% endif %}
+        {% if violation.consequence %}
+        <p class="violation-consequence"><strong>Consequence:</strong> {{ violation.consequence }}</p>
+        {% endif %}
         {% if violation.evidencePoints and violation.evidencePoints | length %}
         <ul>
           {% for point in violation.evidencePoints %}


### PR DESCRIPTION
## Summary
- render each violation's consequence on the brief page when data is provided
- remove stray trailing characters from `_data/briefs.json` so Eleventy can parse the dataset cleanly

## Testing
- npm run build *(fails: Eleventy reports duplicate permalink output between `overproof.njk` and `brief.njk` targeting `_site/proofs/the-aac-formation-conspiracy/index.html`)*

------
https://chatgpt.com/codex/tasks/task_e_68cd796a8f748330839a36080f4a1136