### PR TITLE
Add proof data JSON payload to home page

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -62,6 +62,10 @@ description: Proof. Not spin. Democratic Justice equips West Virginia Democrats 
         <!-- JavaScript will fill this area -->
     </div>
 
+    <script type="application/json" id="proof-data">
+      {{ collections.sortedProofs | dump | replace('</', '<\\/') | safe }}
+    </script>
+
     <div style="margin-top:40px">
       <a href="{{ '/archive' | url }}" class="btn btn-outline-blue">View Full Proof Archive</a>
     </div>


### PR DESCRIPTION
## Summary
- embed the proofs collection JSON payload on the home page so the navigation module can render the grid data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce3997b96483308fda038a4b5ce8b7