### PR TITLE
Define spacing tokens and replace ad-hoc gaps

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,4 +1,18 @@
 /* =========================================
+   Spacing scale & usage (16px base)
+   -----------------------------------------
+   --space-1: 0.25rem (4px)   micro adjustments, icon padding
+   --space-2: 0.5rem  (8px)   compact gaps within controls
+   --space-3: 0.75rem (12px)  default in-component spacing
+   --space-4: 1rem    (16px)  container padding & tight stacks
+   --space-5: 1.5rem  (24px)  card padding & dense layout gutters
+   --space-6: 2rem    (32px)  layout gutters and media padding
+   --space-7: 2.5rem  (40px)  spacing between grouped components
+   --space-8: 3rem    (48px)  generous component gutters
+   --space-9: 6rem    (96px)  full section separation
+   Use --space-1 through --space-3 inside components and reserve --space-5 and larger for spacing between major elements and sections.
+   ========================================= */
+/* =========================================
     Clean Modern Palette
     ========================================= */
 :root{
@@ -73,7 +87,16 @@
   --accent-600: color-mix(in srgb, var(--brand) 85%, black);
   --accent-50:  color-mix(in srgb, var(--brand) 10%, white);
 
-  --cap:56px; --section-gap:80px; --gap:40px;
+  /* Spacing scale */
+  --space-1: 0.25rem; /* 4px */
+  --space-2: 0.5rem;  /* 8px */
+  --space-3: 0.75rem; /* 12px */
+  --space-4: 1rem;    /* 16px */
+  --space-5: 1.5rem;  /* 24px */
+  --space-6: 2rem;    /* 32px */
+  --space-7: 2.5rem;  /* 40px */
+  --space-8: 3rem;    /* 48px */
+  --space-9: 6rem;    /* 96px */
 }
 
 [data-theme="dark"]{
@@ -205,22 +228,22 @@ body{
 }
 img{max-width:100%;display:block}
 a{text-decoration:none}
-.align-container{max-width:1000px;margin:0 auto;padding:0 16px}
+.align-container{max-width:1000px;margin:0 auto;padding:0 var(--space-4)}
 
 /* Skip Link */
 .skip{position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden}
-.skip:focus{left:20px;top:12px;width:auto;height:auto;background:var(--brand);color:var(--white);padding:8px 16px;border-radius:8px;z-index:1000}
+.skip:focus{left:calc(var(--space-3) + var(--space-2));top:var(--space-3);width:auto;height:auto;background:var(--brand);color:var(--white);padding:var(--space-2) var(--space-4);border-radius:8px;z-index:1000}
 
 /* Typography */
-h1{font-family:'Oswald',Impact,sans-serif;font-size:clamp(42px,6vw,72px);line-height:1.05;text-transform:uppercase;font-weight:700;letter-spacing:-.02em;margin-bottom:24px}
+h1{font-family:'Oswald',Impact,sans-serif;font-size:clamp(42px,6vw,72px);line-height:1.05;text-transform:uppercase;font-weight:700;letter-spacing:-.02em;margin-bottom:var(--space-5)}
 h1 strong{color:var(--brand);display:block}
-h2{font-family:'Oswald',Impact,sans-serif;text-transform:uppercase;font-size:clamp(28px,4vw,42px);line-height:1.1;font-weight:700;letter-spacing:.02em;margin-bottom:24px}
-h3{font-family:'Oswald',Impact,sans-serif;text-transform:uppercase;font-size:20px;font-weight:700;letter-spacing:.5px;margin-bottom:8px}
-p{max-width:65ch;margin-bottom:16px}
+h2{font-family:'Oswald',Impact,sans-serif;text-transform:uppercase;font-size:clamp(28px,4vw,42px);line-height:1.1;font-weight:700;letter-spacing:.02em;margin-bottom:var(--space-5)}
+h3{font-family:'Oswald',Impact,sans-serif;text-transform:uppercase;font-size:20px;font-weight:700;letter-spacing:.5px;margin-bottom:var(--space-2)}
+p{max-width:65ch;margin-bottom:var(--space-4)}
 
 /* Brand helpers */
-.wordmark{height:var(--cap);width:auto}
-.footer-logo{height:40px;width:auto}
+.wordmark{height:calc(var(--space-8) + var(--space-2));width:auto}
+.footer-logo{height:var(--space-7);width:auto}
 .mark{height:20px;width:auto;display:inline-block;vertical-align:-.15em}
 .mark.md{height:18px}
 .mark.xl{height:32px}
@@ -246,9 +269,9 @@ p{max-width:65ch;margin-bottom:16px}
   display:flex;
   align-items:center;
   justify-content:space-between;
-  padding:12px 0;
+  padding: var(--space-3) 0;
 }
-.logo-wrap{display:flex;align-items:center;gap:12px}
+.logo-wrap{display:flex;align-items:center;gap:var(--space-3)}
 .nav-links{
   display:none;
   flex-direction:column;
@@ -257,8 +280,8 @@ p{max-width:65ch;margin-bottom:16px}
   left:0;
   right:0;
   background:var(--paper-light);
-  padding:16px 20px;
-  gap:12px;
+  padding: var(--space-4) calc(var(--space-3) + var(--space-2));
+  gap: var(--space-3);
   box-shadow:0 4px 8px rgba(0,0,0,.1);
   list-style:none;
 }
@@ -274,7 +297,7 @@ p{max-width:65ch;margin-bottom:16px}
   text-transform:uppercase;
   font-size:14px;
   letter-spacing:.5px;
-  padding:12px 16px;
+  padding: var(--space-3) var(--space-4);
   min-width:44px;
   min-height:44px;
   border-bottom:2px solid transparent;
@@ -331,8 +354,8 @@ p{max-width:65ch;margin-bottom:16px}
     left:auto;
     right:auto;
     background:transparent;
-    padding:0;
-    gap:24px;
+    padding: 0;
+    gap: var(--space-5);
     box-shadow:none;
     align-items:center;
   }
@@ -351,14 +374,14 @@ p{max-width:65ch;margin-bottom:16px}
   color:var(--white);
   z-index:100;
   box-shadow:0 -2px 8px rgba(15,39,66,.08);
-  padding-bottom:env(safe-area-inset-bottom);
+  padding-bottom: env(safe-area-inset-bottom);
 }
 .bottom-nav-links{
   display:flex;
   justify-content:space-around;
   list-style:none;
-  margin:0;
-  padding:0;
+  margin: 0;
+  padding: 0;
 }
 .bottom-nav-links a{
   flex:1;
@@ -389,7 +412,7 @@ p{max-width:65ch;margin-bottom:16px}
   cursor:pointer;
   font-size:18px;
   line-height:1;
-  padding:4px;
+  padding: var(--space-1);
   color:var(--brand);
 }
 
@@ -400,7 +423,7 @@ p{max-width:65ch;margin-bottom:16px}
 .hero{
   background-color: var(--navy);
   color: var(--white);
-  padding: var(--section-gap) 0;
+  padding: calc(var(--space-8) + var(--space-6)) 0;
   position: relative;
 }
 
@@ -438,7 +461,7 @@ p{max-width:65ch;margin-bottom:16px}
 .hero-grid{
   display: grid;
   grid-template-columns: 1fr;
-  gap: var(--gap);
+  gap: var(--space-7);
   align-items: center;
 }
 @media (min-width:769px){
@@ -449,9 +472,9 @@ p{max-width:65ch;margin-bottom:16px}
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  gap:10px;
-  min-height:56px;
-  padding:0 24px;
+  gap: var(--space-2);
+  min-height: calc(var(--space-8) + var(--space-2));
+  padding: 0 var(--space-5);
   font-weight:700;
   border-radius:10px;
   text-transform:uppercase;
@@ -499,9 +522,9 @@ p{max-width:65ch;margin-bottom:16px}
 }
 .btn-group{
   display:flex;
-  gap:16px;
+  gap: var(--space-4);
   flex-wrap:wrap;
-  margin-top:8px;
+  margin-top: var(--space-2);
 }
 
 /* Proof Box */
@@ -518,32 +541,32 @@ p{max-width:65ch;margin-bottom:16px}
   display:flex;
   align-items:center;
   justify-content:space-between;
-  gap:10px;
+  gap: var(--space-2);
   background:var(--slate);
   color:var(--white);
-  padding:14px 18px;
+  padding: calc(var(--space-3) + var(--space-1)) calc(var(--space-4) + var(--space-1));
 }
 .proof-box__title{
   display:flex;
   align-items:center;
-  gap:10px;
+  gap: var(--space-3);
   font-family:'Oswald',Impact,sans-serif;
   text-transform:uppercase;
   font-size:18px;
   letter-spacing:2px;
   font-weight:700;
 }
-.proof-box__content{padding:24px 20px}
+.proof-box__content{padding:var(--space-5) calc(var(--space-3) + var(--space-2))}
 .proof-box__finding{
   font-size:18px;
   font-weight:700;
   line-height:1.4;
-  margin-bottom:12px;
+  margin-bottom: var(--space-3);
 }
 .proof-box__meta{
   color:var(--text-muted);
   font-size:14px;
-  margin-bottom:16px;
+  margin-bottom: var(--space-4);
 }
 .proof-box__cta{
   color:var(--brand);
@@ -553,7 +576,7 @@ p{max-width:65ch;margin-bottom:16px}
   letter-spacing:.5px;
   display:inline-flex;
   align-items:center;
-  gap:6px;
+  gap: var(--space-2);
   border-bottom:2px solid transparent;
 }
 .proof-box__cta:hover{
@@ -567,13 +590,13 @@ p{max-width:65ch;margin-bottom:16px}
   color:var(--navy);
   font-size:14px;
   letter-spacing:2px;
-  margin-bottom:8px;
+  margin-bottom: var(--space-2);
   font-weight:700;
 }
 
 /* Cases/Archive */
 .cases{
-  padding:var(--section-gap) 0;
+  padding: calc(var(--space-8) + var(--space-6)) 0;
   background:var(--light);
   border-top:1px solid color-mix(in srgb, var(--silver) 30%, transparent);
   border-bottom:1px solid color-mix(in srgb, var(--silver) 30%, transparent);
@@ -581,15 +604,15 @@ p{max-width:65ch;margin-bottom:16px}
 .case-grid{
   display:grid;
   grid-template-columns:1fr;
-  gap:24px;
-  margin-top:var(--gap);
+  gap: var(--space-5);
+  margin-top: var(--space-7);
 }
 .case-card{
   background:var(--paper-light);
   border:1px solid color-mix(in srgb, var(--silver) 30%, transparent);
   border-left:4px solid var(--navy);
   border-radius:10px;
-  padding:16px;
+  padding: var(--space-4);
   transition:transform .2s,box-shadow .2s;
   box-shadow:0 2px 8px rgba(15,39,66,.05);
 }
@@ -625,7 +648,7 @@ p{max-width:65ch;margin-bottom:16px}
   letter-spacing:.5px;
   display:inline-flex;
   align-items:center;
-  gap:6px;
+  gap: var(--space-2);
 }
 [data-theme="dark"] .case-card h3 a,
 [data-theme="dark"] .case-link{
@@ -637,7 +660,7 @@ p{max-width:65ch;margin-bottom:16px}
   width:18px;
   height:18px;
   background:url('images/three-dots-blue.svg') no-repeat center/contain;
-  margin-right:2px;
+  margin-right: 2px;
   transform:translateY(2px);
 }
 .case-card:hover .case-link::before{
@@ -646,11 +669,11 @@ p{max-width:65ch;margin-bottom:16px}
 
 /* Method Section */
 .method{
-  padding:var(--section-gap) 0;
+  padding: calc(var(--space-8) + var(--space-6)) 0;
   background:var(--paper);
 }
 .method-single-box {
-  margin-top: 40px;
+  margin-top: var(--space-7);
   background-color: var(--paper-light);
   border-radius: 12px;
   overflow: hidden;
@@ -662,7 +685,7 @@ p{max-width:65ch;margin-bottom:16px}
 .method-single-box__header {
   background-color: var(--slate);
   color: var(--white);
-  padding: 18px 24px;
+  padding: 18px var(--space-5);
 }
 .method-single-box__header h3 {
   font-family: 'Oswald', Impact, sans-serif;
@@ -673,7 +696,7 @@ p{max-width:65ch;margin-bottom:16px}
   margin-bottom: 0;
 }
 .method-single-box__item {
-  padding: 20px 24px;
+  padding: calc(var(--space-3) + var(--space-2)) var(--space-5);
   border-bottom: 1px solid var(--silver);
 }
 .method-single-box__item:last-child {
@@ -685,7 +708,7 @@ p{max-width:65ch;margin-bottom:16px}
   font-weight: 700;
   text-transform: uppercase;
   color: var(--brand);
-  margin-bottom: 4px;
+  margin-bottom: var(--space-1);
 }
 .method-step-description {
   font-size: 16px;
@@ -695,7 +718,7 @@ p{max-width:65ch;margin-bottom:16px}
 
 /* Action Section */
 .action{
-  padding:var(--section-gap) 0;
+  padding: calc(var(--space-8) + var(--space-6)) 0;
   background:var(--paper-light);
   border-top:1px solid color-mix(in srgb, var(--silver) 30%, transparent);
 }
@@ -703,17 +726,17 @@ p{max-width:65ch;margin-bottom:16px}
   background:var(--paper-light);
   border:1px solid color-mix(in srgb, var(--silver) 30%, transparent);
   border-radius:10px;
-  padding:24px;
+  padding: var(--space-5);
 }
 .action-list{
-  margin:12px 0 16px 0;
+  margin: var(--space-3) 0 var(--space-4) 0;
   list-style:none;
-  padding-left:0;
+  padding-left: 0;
 }
 .action-list li{
-  padding-left:1.5em;
+  padding-left: 1.5em;
   position:relative;
-  margin:6px 0;
+  margin: var(--space-2) 0;
 }
 .action-list li::before{
   content:"";
@@ -731,25 +754,25 @@ p{max-width:65ch;margin-bottom:16px}
   display:flex;
   align-items:center;
   justify-content:flex-start;
-  gap:12px;
+  gap: var(--space-3);
 }
 
 /* CTA Section */
 .cta-section{
-  padding:var(--section-gap) 0;
+  padding: calc(var(--space-8) + var(--space-6)) 0;
   background:var(--paper);
 }
 .cta-form{
   display:flex;
   flex-direction:column;
-  gap:12px;
-  margin-top:24px;
+  gap: var(--space-3);
+  margin-top: var(--space-5);
   max-width:480px;
 }
 .cta-form input,
 .cta-form textarea,
 .cta-form select{
-  padding:12px 16px;
+  padding: var(--space-3) var(--space-4);
   border:1px solid var(--muted);
   border-radius:8px;
   font-size:16px;
@@ -758,7 +781,7 @@ p{max-width:65ch;margin-bottom:16px}
 .cta-form .form-group{
   display:flex;
   flex-direction:column;
-  gap:4px;
+  gap: var(--space-1);
 }
 .cta-form .form-group label{
   font-weight:600;
@@ -769,11 +792,11 @@ p{max-width:65ch;margin-bottom:16px}
   display:inline-flex;
   align-items:center;
   justify-content:center;
-  gap:8px;
+  gap: var(--space-2);
   background:var(--brand);
   color:var(--white);
   border:2px solid var(--brand);
-  padding:12px 24px;
+  padding: var(--space-3) var(--space-5);
   border-radius:8px;
   font-weight:700;
   text-transform:uppercase;
@@ -789,32 +812,32 @@ p{max-width:65ch;margin-bottom:16px}
   border-color:var(--navy);
 }
 .multi-step-form{
-  gap:24px;
+  gap: var(--space-5);
 }
 .multi-step-form fieldset{
   border:0;
-  margin:0;
-  padding:0;
+  margin: 0;
+  padding: 0;
   display:flex;
   flex-direction:column;
-  gap:16px;
+  gap: var(--space-4);
 }
 .multi-step-form legend{
   font-weight:700;
   color:var(--navy);
   font-size:1.05rem;
-  margin-bottom:4px;
+  margin-bottom: var(--space-1);
 }
 .form-progress{
   display:flex;
   flex-wrap:wrap;
-  gap:8px;
+  gap: var(--space-2);
   list-style:none;
-  padding:0;
-  margin:0;
+  padding: 0;
+  margin: 0;
 }
 .form-progress li{
-  padding:6px 12px;
+  padding: var(--space-2) var(--space-3);
   border:1px solid var(--muted);
   border-radius:999px;
   font-size:.8rem;
@@ -835,7 +858,7 @@ p{max-width:65ch;margin-bottom:16px}
   font-size:.85rem;
   font-weight:600;
   color:var(--muted);
-  margin:8px 0 12px;
+  margin: var(--space-2) 0 var(--space-3);
 }
 .form-label{
   font-weight:600;
@@ -850,36 +873,36 @@ p{max-width:65ch;margin-bottom:16px}
 .form-options{
   display:flex;
   flex-direction:column;
-  gap:8px;
-  margin-top:4px;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
 }
 .form-option{
   display:flex;
   align-items:flex-start;
-  gap:10px;
+  gap: var(--space-2);
   cursor:pointer;
   font-weight:500;
   color:var(--navy);
 }
 .form-option input{
-  margin-top:4px;
+  margin-top: var(--space-1);
   accent-color:var(--brand);
 }
 .form-alert{
   background:rgba(222,59,59,.1);
   border-left:4px solid var(--danger-text);
-  padding:12px 16px;
+  padding: var(--space-3) var(--space-4);
   border-radius:8px;
   font-size:.85rem;
   color:var(--danger-text);
-  margin:0;
+  margin: 0;
 }
 .form-navigation{
   display:flex;
   flex-wrap:wrap;
-  gap:12px;
+  gap: var(--space-3);
   align-items:center;
-  margin-top:8px;
+  margin-top: var(--space-2);
 }
 .cta-form .btn-secondary{
   background:transparent;
@@ -895,23 +918,23 @@ p{max-width:65ch;margin-bottom:16px}
   background:var(--paper-light);
   border:1px solid var(--muted);
   border-radius:12px;
-  padding:24px;
-  margin-top:24px;
+  padding: var(--space-5);
+  margin-top: var(--space-5);
   max-width:520px;
   box-shadow:0 10px 30px rgba(0,0,0,.08);
 }
 .form-success h3{
-  margin-top:0;
-  margin-bottom:8px;
+  margin-top: 0;
+  margin-bottom: var(--space-2);
 }
 .form-success p{
-  margin:0;
+  margin: 0;
   font-size:.95rem;
   line-height:1.6;
 }
 #cta-error{
   font-size:13px;
-  margin-top:16px;
+  margin-top: var(--space-4);
   color:var(--danger-text);
   display:none;
 }
@@ -921,17 +944,17 @@ p{max-width:65ch;margin-bottom:16px}
   position:relative;
   background:var(--navy);
   color:var(--white);
-  padding:var(--gap) 0;
+  padding: var(--space-7) 0;
 }
 .footer-top{
   display:flex;
   align-items:center;
-  gap:12px;
-  margin-bottom:8px;
+  gap: var(--space-3);
+  margin-bottom: var(--space-2);
 }
 .footer p{
   max-width:65ch;
-  margin-bottom:16px;
+  margin-bottom: var(--space-4);
   opacity:.9;
   font-size:14px;
   line-height:1.6;
@@ -945,7 +968,7 @@ p{max-width:65ch;margin-bottom:16px}
   border-bottom:1px solid var(--brand);
   display:inline-flex;
   align-items:center;
-  gap:6px;
+  gap: var(--space-2);
 }
 .footer a:hover{
   background:var(--brand);
@@ -969,20 +992,20 @@ p{max-width:65ch;margin-bottom:16px}
   border-radius:12px;
   max-width:480px;
   width:90%;
-  padding:24px;
+  padding: var(--space-5);
   box-shadow:0 20px 60px rgba(0,0,0,.4);
 }
 .modal__actions{
   display:flex;
   justify-content:flex-end;
-  margin-top:16px;
+  margin-top: var(--space-4);
 }
 .modal__close{
   background:var(--brand);
   color:var(--white);
   border:2px solid var(--brand);
   border-radius:8px;
-  padding:10px 16px;
+  padding: var(--space-2) var(--space-4);
   font-weight:700;
   text-transform:uppercase;
   cursor:pointer;
@@ -1009,13 +1032,13 @@ p{max-width:65ch;margin-bottom:16px}
 .search-filter-controls {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 16px;
-  margin: 32px 0;
+  gap: var(--space-4);
+  margin: var(--space-6) 0;
   align-items: center;
 }
 .search-filter-controls input[type="search"] {
   width: 100%;
-  padding: 12px 16px;
+  padding: var(--space-3) var(--space-4);
   font-size: 16px;
   border-radius: 8px;
   border: 1px solid var(--silver);
@@ -1025,11 +1048,11 @@ p{max-width:65ch;margin-bottom:16px}
 }
 .filter-group {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
 }
 .search-filter-controls select {
   flex-grow: 1;
-  padding: 12px 16px;
+  padding: var(--space-3) var(--space-4);
   font-size: 16px;
   border-radius: 8px;
   border: 1px solid var(--silver);
@@ -1048,7 +1071,7 @@ p{max-width:65ch;margin-bottom:16px}
   border-color: var(--border-strong);
 }
 .btn-reset {
-  padding: 12px 16px;
+  padding: var(--space-3) var(--space-4);
   border-radius: 8px;
   border: 1px solid var(--silver);
   background: var(--light);
@@ -1072,7 +1095,7 @@ p{max-width:65ch;margin-bottom:16px}
 .status-badge {
   display: inline-flex;
   align-items: center;
-  padding: 4px 10px;
+  padding: var(--space-1) 10px;
   border-radius: 6px;
   font-size: 11px;
   font-weight: 700;
@@ -1111,8 +1134,8 @@ p{max-width:65ch;margin-bottom:16px}
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 8px;
-  margin-bottom: 12px;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
 }
 
 /* Responsive adjustments for search */
@@ -1122,7 +1145,7 @@ p{max-width:65ch;margin-bottom:16px}
 }
 
 /* Section wrapper padding (all breakpoints) */
-.content-page { padding: var(--section-gap) 0; }
+.content-page { padding: calc(var(--space-8) + var(--space-6)) 0; }
 
 /* === Anchors & Action page === */
 
@@ -1131,11 +1154,11 @@ html { scroll-behavior: smooth; }
 @media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
 
 /* Offset home-page jump links so sticky header doesn't cover them */
-:root { --sticky-offset: calc(var(--cap) + 28px); } /* tweak +28px if needed */
+:root { --sticky-offset: calc(var(--space-8) + var(--space-2) + var(--space-4) + var(--space-3)); } /* adjust additive terms if header height changes */
 #archive, #method, #action, #cta { scroll-margin-top: var(--sticky-offset); }
 
 /* Action page section offset (for in-page shortcuts) */
-#action-page .action-item { scroll-margin-top: 96px; } /* adjust to your header height */
+#action-page .action-item { scroll-margin-top: var(--space-9); } /* adjust to your header height */
 
 /* Shortcut nav */
 .action-shortcuts {
@@ -1188,9 +1211,9 @@ html { scroll-behavior: smooth; }
 
 /* === About page: subtle founder afterword === */
 #about-page .founder-afterword {
-  margin: 18px 0 8px;
+  margin: 18px 0 var(--space-2);
   border-top: 1px solid var(--silver);
-  padding-top: 12px;
+  padding-top: var(--space-3);
 }
 #about-page .founder-inline {
   display: grid;
@@ -1227,14 +1250,14 @@ html { scroll-behavior: smooth; }
   border-left: 4px solid var(--navy);
   border-radius: 10px;
   box-shadow: 0 1px 2px rgba(15,39,66,.06);
-  padding: 14px 16px;
-  margin: 16px 0;
+  padding: 14px var(--space-4);
+  margin: var(--space-4) 0;
 }
 
 #about-page .context-note h3 {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
   margin: 0 0 6px;
   font-size: clamp(18px, 2.6vw, 20px);
   letter-spacing: .5px;
@@ -1571,7 +1594,7 @@ html { scroll-behavior: smooth; }
 .key-facts-box {
   background: var(--surface-soft);
   border-left: 4px solid var(--brand);
-  padding: 20px; margin: 24px 0; border-radius: 4px;
+  padding: calc(var(--space-3) + var(--space-2)); margin: 24px 0; border-radius: 4px;
 }
 .key-facts-box h4 { margin: 0 0 15px 0; color: var(--navy-soft); font-size: 18px; font-weight: 600; }
 .key-facts-box ul { list-style: none; padding: 0; margin: 0; }
@@ -1660,9 +1683,9 @@ html { scroll-behavior: smooth; }
   background: var(--navy);
   color:var(--white);
   border-radius:18px;
-  padding:28px;
+  padding: calc(var(--space-4) + var(--space-3));
   box-shadow:0 20px 60px rgba(0,0,0,.35);
-  margin:0 0 24px;
+  margin: 0 0 var(--space-5);
 }
 .proof-kicker{
   display:inline-flex; align-items:center; gap:8px;
@@ -1748,7 +1771,7 @@ html { scroll-behavior: smooth; }
 /* Fix falsifiability checklist bullets */
 #proof-page .falsifiability ul{
   list-style: none;          /* remove native bullets */
-  margin: 8px 0 0;
+  margin: var(--space-2) 0 0;
   padding-left: 0;
 }
 
@@ -1779,7 +1802,7 @@ html { scroll-behavior: smooth; }
   border:1px solid var(--border-subtle);
   border-radius:12px;
   box-shadow:0 6px 24px rgba(0,0,0,.08);
-  padding:24px 24px 20px;
+  padding: var(--space-5) var(--space-5) calc(var(--space-3) + var(--space-2));
 }
 
 /* Header (no blue slab) */
@@ -1923,7 +1946,7 @@ html { scroll-behavior: smooth; }
    =============================================== */
 
 #proof-page .doc {
-  margin: 40px auto;
+  margin: var(--space-7) auto;
   max-width: 900px;
   background: var(--paper-light);
   border: 3px solid var(--ink-strong);
@@ -1932,13 +1955,13 @@ html { scroll-behavior: smooth; }
 }
 
 #proof-page .doc-header {
-  padding: 32px 32px 32px; /* Sets space below title */
+  padding: var(--space-6) var(--space-6) var(--space-6); /* Sets space below title */
   margin: 0;
   position: relative;
 }
 
 #proof-page .doc-body {
-  padding: 0 32px 32px; /* No top padding */
+  padding: 0 var(--space-6) var(--space-6); /* No top padding */
 }
 
 /* --- Header Elements --- */
@@ -1946,7 +1969,7 @@ html { scroll-behavior: smooth; }
 #proof-page .doc-mark span {
   background: var(--ink-strong);
   color: var(--white);
-  padding: 6px 16px;
+  padding: 6px var(--space-4);
   border-radius: 6px;
   font-weight: 900;
   font-size: 0.9rem;
@@ -2066,7 +2089,7 @@ html { scroll-behavior: smooth; }
   background: var(--paper-light);
   border: 3px solid var(--border-subtle);
   border-radius: 12px;
-  padding: 24px 24px 24px 48px;
+  padding: var(--space-5) var(--space-5) var(--space-5) var(--space-8);
   margin-bottom: 1.25rem;
   position: relative;
   transition: all 0.2s;
@@ -2092,22 +2115,22 @@ html { scroll-behavior: smooth; }
   font-size: 1.2rem;
   font-weight: 700;
   color: var(--ink-strong);
-  margin: 0 0 12px;
+  margin: 0 0 var(--space-3);
   line-height: 1.5;
 }
 
 .offense-card .citation {
   font-size: 0.9rem;
   color: var(--text-hint);
-  margin: 12px 0 0;
-  padding-top: 12px;
+  margin: var(--space-3) 0 0;
+  padding-top: var(--space-3);
   border-top: 1px solid var(--surface-divider);
   font-style: normal;
 }
 
 .offense-card .citation::before {
   content: "📎 ";
-  margin-right: 4px;
+  margin-right: var(--space-1);
 }
 
 /* --- Logic Chain --- */
@@ -2122,7 +2145,7 @@ html { scroll-behavior: smooth; }
   background: var(--paper-light);
   border: 2px solid var(--border-subtle);
   border-radius: 12px;
-  padding: 20px 24px 20px 60px;
+  padding: calc(var(--space-3) + var(--space-2)) var(--space-5) calc(var(--space-3) + var(--space-2)) 60px;
   margin-bottom: 1.25rem;
   position: relative;
   font-size: 1.125rem;
@@ -2161,7 +2184,7 @@ html { scroll-behavior: smooth; }
   color: var(--white);
   border: 3px solid var(--brand-deep);
   border-radius: 12px;
-  padding: 28px 28px 28px 72px;
+  padding: calc(var(--space-4) + var(--space-3)) calc(var(--space-4) + var(--space-3)) calc(var(--space-4) + var(--space-3)) 72px;
   font-size: 1.375rem;
   font-weight: 800;
   box-shadow: 0 12px 32px rgba(37, 99, 235, 0.25);
@@ -2178,7 +2201,7 @@ html { scroll-behavior: smooth; }
   background: linear-gradient(135deg, var(--surface-success-strong) 0%, var(--surface-success) 100%);
   border: 3px solid var(--success);
   border-radius: 12px;
-  padding: 24px;
+  padding: var(--space-5);
   margin-top: 2rem;
   box-shadow: 0 8px 24px rgba(34, 197, 94, 0.1);
 }
@@ -2190,12 +2213,12 @@ html { scroll-behavior: smooth; }
   font-size: 0.9rem;
   letter-spacing: 1.5px;
   display: block;
-  margin-bottom: 16px;
+  margin-bottom: var(--space-4);
 }
 
 .remedy ul {
   margin: 0;
-  padding-left: 24px;
+  padding-left: var(--space-5);
   list-style: none;
 }
 
@@ -2203,9 +2226,9 @@ html { scroll-behavior: smooth; }
   font-weight: 700;
   font-size: 1.125rem;
   color: var(--ink-strong);
-  margin-bottom: 12px;
+  margin-bottom: var(--space-3);
   position: relative;
-  padding-left: 24px;
+  padding-left: var(--space-5);
 }
 
 .remedy li::before {
@@ -2225,7 +2248,7 @@ html { scroll-behavior: smooth; }
 .action-tool a {
   background: var(--ink-strong);
   color: var(--white);
-  padding: 16px 32px;
+  padding: var(--space-4) var(--space-6);
   border-radius: 12px;
   text-decoration: none;
   font-weight: 900;
@@ -2247,7 +2270,7 @@ html { scroll-behavior: smooth; }
 
 .doc-header,
 .doc-body {
-  padding: 24px;
+  padding: var(--space-5);
 }
 
 .doc-title {
@@ -2279,16 +2302,16 @@ html { scroll-behavior: smooth; }
 .filter-badges {
     display: flex;
     flex-wrap: wrap;
-    gap: 8px;
-    margin: 16px 0;
+    gap: var(--space-2);
+    margin: var(--space-4) 0;
     min-height: 32px;
 }
 
 .filter-badge {
     display: inline-flex;
     align-items: center;
-    gap: 8px;
-    padding: 6px 12px;
+    gap: var(--space-2);
+    padding: 6px var(--space-3);
     background: var(--brand);
     color: var(--white);
     border-radius: 20px;
@@ -2316,7 +2339,7 @@ html { scroll-behavior: smooth; }
     background: var(--paper-light);
     border: 2px solid var(--brand);
     color: var(--brand);
-    padding: 10px 20px;
+    padding: 10px calc(var(--space-3) + var(--space-2));
     border-radius: 8px;
     font-weight: 700;
     cursor: pointer;
@@ -2334,21 +2357,21 @@ html { scroll-behavior: smooth; }
 }
 
 .timeline-month {
-    margin-bottom: 40px;
+    margin-bottom: var(--space-7);
 }
 
 .timeline-month-header {
     font-size: 24px;
     color: var(--text);
     border-bottom: 2px solid var(--brand);
-    padding-bottom: 8px;
-    margin-bottom: 20px;
+    padding-bottom: var(--space-2);
+    margin-bottom: calc(var(--space-3) + var(--space-2));
 }
 
 .timeline-entry {
     display: flex;
-    gap: 20px;
-    margin-bottom: 24px;
+    gap: calc(var(--space-3) + var(--space-2));
+    margin-bottom: var(--space-5);
     padding-left: 60px;
     position: relative;
 }
@@ -2374,7 +2397,7 @@ html { scroll-behavior: smooth; }
     background: var(--paper-light);
     border: 1px solid var(--silver);
     border-radius: 8px;
-    padding: 16px;
+    padding: var(--space-4);
 }
 
 .timeline-category {
@@ -2383,11 +2406,11 @@ html { scroll-behavior: smooth; }
     font-weight: 700;
     text-transform: uppercase;
     color: var(--muted);
-    margin-bottom: 8px;
+    margin-bottom: var(--space-2);
 }
 
 .timeline-content h4 {
-    margin: 8px 0;
+    margin: var(--space-2) 0;
     font-size: 18px;
 }
 
@@ -2402,13 +2425,13 @@ html { scroll-behavior: smooth; }
 
 .proof-type-badge {
     display: inline-block;
-    padding: 4px 10px;
+    padding: var(--space-1) 10px;
     border-radius: 6px;
     font-size: 11px;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    margin-bottom: 8px;
+    margin-bottom: var(--space-2);
 }
 
 .proof-type-badge.financial-violation {
@@ -2436,9 +2459,9 @@ html { scroll-behavior: smooth; }
   background: linear-gradient(135deg, var(--surface-muted) 0%, var(--surface-info) 100%);
   border: 2px solid var(--brand);
   border-radius: 16px;
-  padding: 24px;
-  margin-top: 16px;
-  margin-bottom: 32px;
+  padding: var(--space-5);
+  margin-top: var(--space-4);
+  margin-bottom: var(--space-6);
   position: relative;
   overflow: hidden;
 }
@@ -2449,7 +2472,7 @@ html { scroll-behavior: smooth; }
   right: 0;
   background: var(--brand);
   color: var(--white);
-  padding: 4px 16px;
+  padding: var(--space-1) var(--space-4);
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 1px;
@@ -2457,13 +2480,13 @@ html { scroll-behavior: smooth; }
 }
 .proof-summary-grid {
   display: grid;
-  gap: 8px;
-  margin-top: 8px;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
 }
 .proof-summary-item {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
   align-items: flex-start;
 }
 .proof-summary-label {
@@ -2491,7 +2514,7 @@ html { scroll-behavior: smooth; }
   -webkit-line-clamp: unset;
 }
 .read-more {
-  margin-top: 4px;
+  margin-top: var(--space-1);
   background: none;
   border: none;
   color: var(--brand);
@@ -2514,9 +2537,9 @@ html { scroll-behavior: smooth; }
 .proof-strength {
   display: flex;
   align-items: center;
-  gap: 8px;
-  margin-top: 16px;
-  padding-top: 16px;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+  padding-top: var(--space-4);
   border-top: 1px solid rgba(0,0,0,0.1);
 }
 .proof-strength-label {
@@ -2528,7 +2551,7 @@ html { scroll-behavior: smooth; }
 }
 .proof-strength-bars {
   display: flex;
-  gap: 4px;
+  gap: var(--space-1);
 }
 .proof-strength-bar {
   width: 20px;
@@ -2546,10 +2569,10 @@ html { scroll-behavior: smooth; }
 .evidence-quality {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  margin-left: 8px;
+  gap: var(--space-1);
+  margin-left: var(--space-2);
   font-size: 11px;
-  padding: 2px 8px;
+  padding: 2px var(--space-2);
   border-radius: 12px;
   background: rgba(59, 130, 246, 0.1);
   color: var(--brand);
@@ -2566,8 +2589,8 @@ html { scroll-behavior: smooth; }
 
 /* ===== Sharing Section ===== */
 .proof-sharing {
-  margin: 48px 0;
-  padding: 32px;
+  margin: var(--space-8) 0;
+  padding: var(--space-6);
   background: var(--surface-muted);
   border-radius: 12px;
   border: 1px solid var(--silver);
@@ -2575,8 +2598,8 @@ html { scroll-behavior: smooth; }
 .sharing-tools {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 32px;
-  margin-top: 24px;
+  gap: var(--space-6);
+  margin-top: var(--space-5);
 }
 .social-card {
   width: 100%;
@@ -2592,28 +2615,28 @@ html { scroll-behavior: smooth; }
 .social-card-header {
   background: var(--brand);
   color: var(--white);
-  padding: 12px 16px;
+  padding: var(--space-3) var(--space-4);
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--space-3);
   font-weight: 700;
   font-size: 14px;
 }
 .social-card-body {
   flex: 1;
-  padding: 20px;
+  padding: calc(var(--space-3) + var(--space-2));
   color: var(--white);
 }
 .social-card-proof {
   color: var(--brand);
   font-weight: 700;
   font-size: 18px;
-  margin-bottom: 12px;
+  margin-bottom: var(--space-3);
 }
 .social-card-title {
   font-size: 24px;
   line-height: 1.2;
-  margin-bottom: 12px;
+  margin-bottom: var(--space-3);
 }
 .social-card-violation {
   font-size: 14px;
@@ -2621,17 +2644,17 @@ html { scroll-behavior: smooth; }
   line-height: 1.4;
 }
 .social-card-footer {
-  padding: 12px 20px;
+  padding: var(--space-3) calc(var(--space-3) + var(--space-2));
   color: var(--brand);
   font-size: 12px;
 }
 .citation-formats {
   display: flex;
-  gap: 8px;
-  margin: 16px 0;
+  gap: var(--space-2);
+  margin: var(--space-4) 0;
 }
 .citation-btn {
-  padding: 8px 16px;
+  padding: var(--space-2) var(--space-4);
   background: var(--paper-light);
   border: 1px solid var(--silver);
   border-radius: 6px;
@@ -2647,14 +2670,14 @@ html { scroll-behavior: smooth; }
   background: var(--paper-light);
   border: 1px solid var(--silver);
   border-radius: 6px;
-  padding: 16px;
+  padding: var(--space-4);
   position: relative;
 }
 .btn-copy {
   position: absolute;
   top: 8px;
   right: 8px;
-  padding: 4px 12px;
+  padding: var(--space-1) var(--space-3);
   background: var(--brand);
   color: var(--white);
   border: none;
@@ -2665,10 +2688,10 @@ html { scroll-behavior: smooth; }
 .share-buttons {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 8px;
+  gap: var(--space-2);
 }
 .share-btn {
-  padding: 12px;
+  padding: var(--space-3);
   background: var(--paper-light);
   border: 1px solid var(--silver);
   border-radius: 6px;
@@ -2684,13 +2707,13 @@ html { scroll-behavior: smooth; }
 
 /* Modern share icons */
 .share-section {
-  margin-top: 32px;
-  padding-top: 24px;
+  margin-top: var(--space-6);
+  padding-top: var(--space-5);
   border-top: 1px solid var(--silver);
 }
 
 .share-cta {
-  margin-top: 40px;
+  margin-top: var(--space-7);
   text-align: center;
 }
 
@@ -2699,7 +2722,7 @@ html { scroll-behavior: smooth; }
   color: var(--white);
   border: none;
   border-radius: 8px;
-  padding: 16px 32px;
+  padding: var(--space-4) var(--space-6);
   font-size: 1.25rem;
   font-weight: 700;
   cursor: pointer;
@@ -2715,7 +2738,7 @@ html { scroll-behavior: smooth; }
 
 .share-icons {
   display: flex;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
 .share-icons a,


### PR DESCRIPTION
## Summary
- document the 16px-based spacing scale and provide custom properties for --space-1 through --space-9
- refactor navigation, hero, section wrappers, and shared components to consume the spacing tokens instead of bespoke pixel gaps
- remove legacy spacing variables and update sticky header offset calculations to rely on the shared spacing scale

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cee448c3288330b1ffb43434caae46