### PR TITLE
Refine typography tokens and overproof layout

### DIFF
--- a/overproof.njk
+++ b/overproof.njk
@@ -65,24 +65,24 @@ eleventyComputed:
 
     {% set heroSummary = (brief and brief.lede) or overproof.summary %}
     {% if heroSummary %}
-    <p class="lead" style="max-width: 60ch;">{{ heroSummary }}</p>
+    <p class="lead">{{ heroSummary }}</p>
     {% endif %}
 
     {% if overproof.narrative %}
-    <div class="overproof-narrative" style="margin-bottom: 2rem; max-width: 70ch;">
+    <div class="overproof-narrative rich-text">
       <p>{{ overproof.narrative | safe }}</p>
     </div>
     {% endif %}
 
-    <div class="overproof-details" style="display: grid; gap: 1.5rem; margin-bottom: 2rem;">
+    <div class="overproof-details">
       {% if overproof.metadata %}
       <div>
-        <h2 class="h4" style="margin-bottom: 0.75rem;">Record Metadata</h2>
-        <dl class="overproof-metadata" style="display: grid; gap: 0.75rem;">
+        <h2 class="h4">Record Metadata</h2>
+        <dl class="overproof-metadata">
           {% for key, value in overproof.metadata %}
-          <div class="overproof-metadata__item" style="display: grid; gap: 0.25rem;">
-            <dt style="font-weight: 700; text-transform: uppercase; font-size: 0.75rem; letter-spacing: 0.08em; color: var(--muted);">{{ key }}</dt>
-            <dd style="margin: 0; font-size: 0.95rem;">{{ value }}</dd>
+          <div class="overproof-metadata__item">
+            <dt class="overproof-metadata__term">{{ key }}</dt>
+            <dd class="overproof-metadata__definition">{{ value }}</dd>
           </div>
           {% endfor %}
         </dl>
@@ -90,15 +90,15 @@ eleventyComputed:
       {% endif %}
 
       <div>
-        <h2 class="h4" style="margin-bottom: 0.75rem;">Proof Count</h2>
-        <p style="font-size: 1.125rem; font-weight: 700;">{{ overproof.proofCount or (overproofGroup.proofs | length) }} proofs documented</p>
+        <h2 class="h4">Proof Count</h2>
+        <p class="overproof-proof-count">{{ overproof.proofCount or (overproofGroup.proofs | length) }} proofs documented</p>
       </div>
     </div>
 
     {% if overproof.key_points and overproof.key_points | length %}
-    <section class="overproof-key-points" aria-labelledby="overproof-key-points-heading" style="margin-bottom: 2.5rem;">
+    <section class="overproof-key-points" aria-labelledby="overproof-key-points-heading">
       <h2 id="overproof-key-points-heading" class="h4">Key Findings</h2>
-      <ul style="margin: 0; padding-left: 1.25rem; display: grid; gap: 0.75rem;">
+      <ul>
         {% for point in overproof.key_points %}
         <li>{{ point }}</li>
         {% endfor %}
@@ -107,7 +107,7 @@ eleventyComputed:
     {% endif %}
 
     {% if brief and brief.violations and brief.violations | length %}
-    <section class="brief-violations" aria-labelledby="brief-violations-heading" style="margin-bottom: 2.5rem;">
+    <section class="brief-violations" aria-labelledby="brief-violations-heading">
       <h2 id="brief-violations-heading">Documented Violations</h2>
       {% for violation in brief.violations %}
       <article class="brief-violation" style="border-top: 1px solid var(--muted-border, rgba(0,0,0,0.1)); padding-top: 1.5rem; margin-top: 1.5rem;">
@@ -148,7 +148,7 @@ eleventyComputed:
     {% endif %}
 
     {% if brief and brief.conclusion %}
-    <section class="brief-conclusion" style="margin-bottom: 2.5rem;">
+    <section class="brief-conclusion">
       <h2>{{ brief.conclusion.headline }}</h2>
       <p>{{ brief.conclusion.summary }}</p>
     </section>

--- a/style.css
+++ b/style.css
@@ -97,6 +97,22 @@
   --space-7: 2.5rem;  /* 40px */
   --space-8: 3rem;    /* 48px */
   --space-9: 6rem;    /* 96px */
+
+  /* Typography scale */
+  --font-size-xs: 0.75rem;
+  --line-height-xs: 1.4;
+  --font-size-sm: 0.875rem;
+  --line-height-sm: 1.5;
+  --font-size-base: 1rem;
+  --line-height-base: 1.6;
+  --font-size-lg: 1.125rem;
+  --line-height-lg: 1.5;
+  --font-size-xl: 1.25rem;
+  --line-height-xl: 1.4;
+  --font-size-2xl: clamp(1.75rem, 4vw, 2.625rem);
+  --line-height-2xl: 1.1;
+  --font-size-3xl: clamp(2.625rem, 6vw, 4.5rem);
+  --line-height-3xl: 1.05;
 }
 
 [data-theme="dark"]{
@@ -223,8 +239,8 @@ body{
   font-family:'Lato',system-ui,-apple-system,sans-serif;
   background:var(--paper);
   color:var(--text);
-  line-height:1.6;
-  font-size:16px;
+  font-size:var(--font-size-base);
+  line-height:var(--line-height-base);
 }
 img{max-width:100%;display:block}
 a{text-decoration:none}
@@ -235,11 +251,60 @@ a{text-decoration:none}
 .skip:focus{left:calc(var(--space-3) + var(--space-2));top:var(--space-3);width:auto;height:auto;background:var(--brand);color:var(--white);padding:var(--space-2) var(--space-4);border-radius:8px;z-index:1000}
 
 /* Typography */
-h1{font-family:'Oswald',Impact,sans-serif;font-size:clamp(42px,6vw,72px);line-height:1.05;text-transform:uppercase;font-weight:700;letter-spacing:-.02em;margin-bottom:var(--space-5)}
+h1{
+  font-family:'Oswald',Impact,sans-serif;
+  font-size:var(--font-size-3xl);
+  line-height:var(--line-height-3xl);
+  text-transform:uppercase;
+  font-weight:700;
+  letter-spacing:-.02em;
+  margin-bottom:var(--space-5);
+}
 h1 strong{color:var(--brand);display:block}
-h2{font-family:'Oswald',Impact,sans-serif;text-transform:uppercase;font-size:clamp(28px,4vw,42px);line-height:1.1;font-weight:700;letter-spacing:.02em;margin-bottom:var(--space-5)}
-h3{font-family:'Oswald',Impact,sans-serif;text-transform:uppercase;font-size:20px;font-weight:700;letter-spacing:.5px;margin-bottom:var(--space-2)}
-p{max-width:65ch;margin-bottom:var(--space-4)}
+h2{
+  font-family:'Oswald',Impact,sans-serif;
+  text-transform:uppercase;
+  font-size:var(--font-size-2xl);
+  line-height:var(--line-height-2xl);
+  font-weight:700;
+  letter-spacing:0.05em;
+  margin-bottom:var(--space-5);
+}
+h3{
+  font-family:'Oswald',Impact,sans-serif;
+  text-transform:uppercase;
+  font-size:var(--font-size-xl);
+  line-height:var(--line-height-xl);
+  font-weight:700;
+  letter-spacing:0.05em;
+  margin-bottom:var(--space-2);
+}
+p{
+  font-size:var(--font-size-base);
+  line-height:var(--line-height-base);
+  max-width:70ch;
+  margin-bottom:var(--space-4);
+}
+
+.lead{
+  font-size:var(--font-size-lg);
+  line-height:var(--line-height-lg);
+  max-width:70ch;
+}
+
+.h4{
+  font-family:'Oswald',Impact,sans-serif;
+  text-transform:uppercase;
+  font-size:var(--font-size-lg);
+  line-height:var(--line-height-xl);
+  font-weight:700;
+  letter-spacing:0.05em;
+  margin-bottom:var(--space-3);
+}
+
+.rich-text{
+  max-width:70ch;
+}
 
 /* Brand helpers */
 .wordmark{height:calc(var(--space-8) + var(--space-2));width:auto}
@@ -295,7 +360,7 @@ p{max-width:65ch;margin-bottom:var(--space-4)}
   color:var(--brand);
   font-weight:700;
   text-transform:uppercase;
-  font-size:14px;
+  font-size:var(--font-size-sm);
   letter-spacing:.5px;
   padding: var(--space-3) var(--space-4);
   min-width:44px;
@@ -391,7 +456,7 @@ p{max-width:65ch;margin-bottom:var(--space-4)}
   color:var(--white);
   font-weight:700;
   text-transform:uppercase;
-  font-size:14px;
+  font-size:var(--font-size-sm);
   letter-spacing:.5px;
   text-decoration:none;
   min-width:44px;
@@ -410,7 +475,7 @@ p{max-width:65ch;margin-bottom:var(--space-4)}
   background:none;
   border:none;
   cursor:pointer;
-  font-size:18px;
+  font-size:var(--font-size-lg);
   line-height:1;
   padding: var(--space-1);
   color:var(--brand);
@@ -478,7 +543,7 @@ p{max-width:65ch;margin-bottom:var(--space-4)}
   font-weight:700;
   border-radius:10px;
   text-transform:uppercase;
-  font-size:14px;
+  font-size:var(--font-size-sm);
   letter-spacing:.5px;
   border:2px solid transparent;
   transition:all .2s;
@@ -552,20 +617,20 @@ p{max-width:65ch;margin-bottom:var(--space-4)}
   gap: var(--space-3);
   font-family:'Oswald',Impact,sans-serif;
   text-transform:uppercase;
-  font-size:18px;
+  font-size:var(--font-size-lg);
   letter-spacing:2px;
   font-weight:700;
 }
 .proof-box__content{padding:var(--space-5) calc(var(--space-3) + var(--space-2))}
 .proof-box__finding{
-  font-size:18px;
+  font-size:var(--font-size-lg);
   font-weight:700;
   line-height:1.4;
   margin-bottom: var(--space-3);
 }
 .proof-box__meta{
   color:var(--text-muted);
-  font-size:14px;
+  font-size:var(--font-size-sm);
   margin-bottom: var(--space-4);
 }
 .proof-box__cta{
@@ -588,7 +653,7 @@ p{max-width:65ch;margin-bottom:var(--space-4)}
   font-family:'Oswald',Impact,sans-serif;
   text-transform:uppercase;
   color:var(--navy);
-  font-size:14px;
+  font-size:var(--font-size-sm);
   letter-spacing:2px;
   margin-bottom: var(--space-2);
   font-weight:700;
@@ -690,7 +755,7 @@ p{max-width:65ch;margin-bottom:var(--space-4)}
 .method-single-box__header h3 {
   font-family: 'Oswald', Impact, sans-serif;
   text-transform: uppercase;
-  font-size: 18px;
+  font-size: var(--font-size-lg);
   letter-spacing: 1px;
   font-weight: 700;
   margin-bottom: 0;
@@ -704,14 +769,14 @@ p{max-width:65ch;margin-bottom:var(--space-4)}
 }
 .method-step-number {
   font-family: 'Oswald', Impact, sans-serif;
-  font-size: 20px;
+  font-size: var(--font-size-xl);
   font-weight: 700;
   text-transform: uppercase;
   color: var(--brand);
   margin-bottom: var(--space-1);
 }
 .method-step-description {
-  font-size: 16px;
+  font-size: var(--font-size-base);
   color: var(--text);
   margin-bottom: 0;
 }
@@ -775,7 +840,7 @@ p{max-width:65ch;margin-bottom:var(--space-4)}
   padding: var(--space-3) var(--space-4);
   border:1px solid var(--muted);
   border-radius:8px;
-  font-size:16px;
+  font-size:var(--font-size-base);
   font-family:inherit;
 }
 .cta-form .form-group{
@@ -785,7 +850,7 @@ p{max-width:65ch;margin-bottom:var(--space-4)}
 }
 .cta-form .form-group label{
   font-weight:600;
-  font-size:0.9rem;
+  font-size:var(--font-size-sm);
   color:var(--muted);
 }
 .cta-form button{
@@ -800,7 +865,7 @@ p{max-width:65ch;margin-bottom:var(--space-4)}
   border-radius:8px;
   font-weight:700;
   text-transform:uppercase;
-  font-size:14px;
+  font-size:var(--font-size-sm);
   letter-spacing:.5px;
   cursor:pointer;
   transition:all .2s;
@@ -929,8 +994,8 @@ p{max-width:65ch;margin-bottom:var(--space-4)}
 }
 .form-success p{
   margin: 0;
-  font-size:.95rem;
-  line-height:1.6;
+  font-size:var(--font-size-base);
+  line-height:var(--line-height-base);
 }
 #cta-error{
   font-size:13px;
@@ -953,11 +1018,11 @@ p{max-width:65ch;margin-bottom:var(--space-4)}
   margin-bottom: var(--space-2);
 }
 .footer p{
-  max-width:65ch;
+  max-width:70ch;
   margin-bottom: var(--space-4);
   opacity:.9;
-  font-size:14px;
-  line-height:1.6;
+  font-size:var(--font-size-sm);
+  line-height:var(--line-height-base);
 }
 .footer strong{
   color:var(--white);
@@ -1039,7 +1104,7 @@ p{max-width:65ch;margin-bottom:var(--space-4)}
 .search-filter-controls input[type="search"] {
   width: 100%;
   padding: var(--space-3) var(--space-4);
-  font-size: 16px;
+  font-size: var(--font-size-base);
   border-radius: 8px;
   border: 1px solid var(--silver);
   font-family: inherit;
@@ -1053,7 +1118,7 @@ p{max-width:65ch;margin-bottom:var(--space-4)}
 .search-filter-controls select {
   flex-grow: 1;
   padding: var(--space-3) var(--space-4);
-  font-size: 16px;
+  font-size: var(--font-size-base);
   border-radius: 8px;
   border: 1px solid var(--silver);
   cursor: pointer;
@@ -1078,7 +1143,7 @@ p{max-width:65ch;margin-bottom:var(--space-4)}
   color: var(--muted);
   cursor: pointer;
   font-weight: 700;
-  font-size: 14px;
+  font-size: var(--font-size-sm);
 }
 .btn-reset:hover {
   background: var(--silver);
@@ -1146,6 +1211,68 @@ p{max-width:65ch;margin-bottom:var(--space-4)}
 
 /* Section wrapper padding (all breakpoints) */
 .content-page { padding: calc(var(--space-8) + var(--space-6)) 0; }
+
+/* Overproof record */
+.overproof-narrative{
+  margin-bottom:var(--space-6);
+}
+
+.overproof-narrative,
+.overproof-key-points,
+.brief-violations,
+.brief-conclusion{
+  max-width:70ch;
+}
+
+.overproof-key-points,
+.brief-violations,
+.brief-conclusion{
+  margin-bottom:var(--space-7);
+}
+
+.overproof-details{
+  display:grid;
+  gap:var(--space-5);
+  margin-bottom:var(--space-6);
+}
+
+.overproof-metadata{
+  display:grid;
+  gap:var(--space-3);
+}
+
+.overproof-metadata__item{
+  display:grid;
+  gap:var(--space-1);
+}
+
+.overproof-metadata__term{
+  font-weight:700;
+  text-transform:uppercase;
+  font-size:var(--font-size-xs);
+  line-height:var(--line-height-xs);
+  letter-spacing:0.08em;
+  color:var(--muted);
+}
+
+.overproof-metadata__definition{
+  margin:0;
+  font-size:var(--font-size-base);
+  line-height:var(--line-height-base);
+}
+
+.overproof-proof-count{
+  font-size:var(--font-size-lg);
+  line-height:var(--line-height-lg);
+  font-weight:700;
+}
+
+.overproof-key-points ul{
+  margin:0;
+  padding-left:1.25rem;
+  display:grid;
+  gap:var(--space-3);
+}
 
 /* === Anchors & Action page === */
 
@@ -1587,7 +1714,10 @@ html { scroll-behavior: smooth; }
 }
 
 .modal-summary {
-  color: var(--text-dim); font-size: 16px; line-height: 1.6; margin-bottom: 24px;
+  color: var(--text-dim);
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-base);
+  margin-bottom: var(--space-5);
 }
 
 /* Swap hard-coded blues to your brand vars */
@@ -1596,13 +1726,13 @@ html { scroll-behavior: smooth; }
   border-left: 4px solid var(--brand);
   padding: calc(var(--space-3) + var(--space-2)); margin: 24px 0; border-radius: 4px;
 }
-.key-facts-box h4 { margin: 0 0 15px 0; color: var(--navy-soft); font-size: 18px; font-weight: 600; }
+.key-facts-box h4 { margin: 0 0 15px 0; color: var(--navy-soft); font-size: var(--font-size-lg); font-weight: 600; }
 .key-facts-box ul { list-style: none; padding: 0; margin: 0; }
 .key-facts-box li { margin-bottom: 10px; padding-left: 24px; position: relative; }
 .key-facts-box li:before { content: "•"; position: absolute; left: 0; color: var(--brand); font-weight: 700; }
 
 .modal-divider { border: none; border-top: 1px solid var(--border-subtle); margin: 24px 0; }
-.modal-body h4 { color: var(--navy-soft); font-size: 18px; font-weight: 600; margin: 24px 0 16px; }
+.modal-body h4 { color: var(--navy-soft); font-size: var(--font-size-lg); font-weight: 600; margin: 24px 0 16px; }
 
 .modal-body ol { padding-left: 0; margin: 0; counter-reset: step-counter; }
 .modal-body ol li {
@@ -1615,11 +1745,11 @@ html { scroll-behavior: smooth; }
   background: var(--brand); color: var(--white);
   width: 28px; height: 28px; border-radius: 50%;
   display: flex; align-items: center; justify-content: center;
-  font-weight: 700; font-size: 14px;
+  font-weight: 700; font-size: var(--font-size-sm);
 }
 .modal-body ol li strong { color: var(--ink-intense); font-weight: 600; }
 .modal-body em { color: var(--text-dim); font-style: italic; }
-.modal-body p { line-height: 1.6; color: var(--text-subtle); }
+.modal-body p { line-height: var(--line-height-base); color: var(--text-subtle); }
 
 /* Lock background scroll when open */
 .body--modal-open { overflow: hidden; }
@@ -2324,7 +2454,7 @@ html { scroll-behavior: smooth; }
     border: none;
     color: var(--white);
     cursor: pointer;
-    font-size: 18px;
+    font-size: var(--font-size-lg);
     line-height: 1;
     padding: 0;
     margin: 0;
@@ -2389,7 +2519,7 @@ html { scroll-behavior: smooth; }
     align-items: center;
     justify-content: center;
     font-weight: 700;
-    font-size: 16px;
+    font-size: var(--font-size-base);
 }
 
 .timeline-content {
@@ -2402,7 +2532,7 @@ html { scroll-behavior: smooth; }
 
 .timeline-category {
     display: inline-block;
-    font-size: 12px;
+    font-size: var(--font-size-xs);
     font-weight: 700;
     text-transform: uppercase;
     color: var(--muted);
@@ -2411,7 +2541,7 @@ html { scroll-behavior: smooth; }
 
 .timeline-content h4 {
     margin: var(--space-2) 0;
-    font-size: 18px;
+    font-size: var(--font-size-lg);
 }
 
 .timeline-content h4 a {
@@ -2493,7 +2623,7 @@ html { scroll-behavior: smooth; }
   flex-shrink: 0;
   font-weight: 700;
   text-transform: uppercase;
-  font-size: 16px;
+  font-size: var(--font-size-base);
   letter-spacing: 0.5px;
   color: var(--text);
   min-width: auto;
@@ -2502,7 +2632,7 @@ html { scroll-behavior: smooth; }
   flex: 1;
   line-height: 1.5;
   color: var(--text);
-  font-size: 16px;
+  font-size: var(--font-size-base);
 }
 .proof-summary-text.clamp {
   display: -webkit-box;
@@ -2519,7 +2649,7 @@ html { scroll-behavior: smooth; }
   border: none;
   color: var(--brand);
   cursor: pointer;
-  font-size: 16px;
+  font-size: var(--font-size-base);
   padding: 0;
 }
 
@@ -2620,7 +2750,7 @@ html { scroll-behavior: smooth; }
   align-items: center;
   gap: var(--space-3);
   font-weight: 700;
-  font-size: 14px;
+  font-size: var(--font-size-sm);
 }
 .social-card-body {
   flex: 1;
@@ -2630,7 +2760,7 @@ html { scroll-behavior: smooth; }
 .social-card-proof {
   color: var(--brand);
   font-weight: 700;
-  font-size: 18px;
+  font-size: var(--font-size-lg);
   margin-bottom: var(--space-3);
 }
 .social-card-title {
@@ -2639,14 +2769,14 @@ html { scroll-behavior: smooth; }
   margin-bottom: var(--space-3);
 }
 .social-card-violation {
-  font-size: 14px;
+  font-size: var(--font-size-sm);
   opacity: 0.9;
   line-height: 1.4;
 }
 .social-card-footer {
   padding: var(--space-3) calc(var(--space-3) + var(--space-2));
   color: var(--brand);
-  font-size: 12px;
+  font-size: var(--font-size-xs);
 }
 .citation-formats {
   display: flex;


### PR DESCRIPTION
## Summary
- add a reusable typography scale with font-size and line-height tokens and wire global text elements to use them with a 70ch long-form width
- replace hard-coded font metrics across buttons, forms, modals, timeline, proof summary, and share cards with the new tokens for consistency
- move overproof narrative and metadata styling out of inline attributes into CSS classes that respect the shared typography rules

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cee7c85e1483308890a2b7599ad95c