### PR TITLE
Align page headings with primary nav labels

### DIFF
--- a/about/index.njk
+++ b/about/index.njk
@@ -8,7 +8,7 @@ permalink: /about/
 <section class="content-page" id="about-page">
   <div class="align-container">
     <p class="section-label">Our Story</p>
-    <h1>Why Democratic Justice Stands with WV Democrats</h1>
+    <h1>About Democratic Justice: Why We Stand with WV Democrats</h1>
 
     <p>We tried working within the system. As Democrats in West Virginia, we filed grievances, raised concerns, and followed proper channels when we witnessed corruption and misconduct. Time after time, our individual efforts were dismissed, isolated, and quietly buried.</p>
 

--- a/action/index.njk
+++ b/action/index.njk
@@ -8,7 +8,7 @@ permalink: /action/
 <section class="content-page" id="action-page">
   <div class="align-container">
     <p class="section-label">Take Action</p>
-    <h1>A Step-by-Step Guide to Filing Grievances</h1>
+    <h1>Action: Step-by-Step Guide to Filing Grievances</h1>
 
     <div class="warning-box" role="note" aria-label="Important filing guidance">
       <p><strong>Follow the process in order.</strong> Procedural errors can lead to dismissal. This guide walks you through the correct steps, starting with seeking a remedy within the state party.</p>

--- a/method.njk
+++ b/method.njk
@@ -8,7 +8,7 @@ permalink: /method/
 <section class="content-page" id="method-page">
   <div class="align-container">
     <p class="section-label">How We Prove It</p>
-    <h1>Our Four-Step Proof Method</h1>
+    <h1>Method: Our Four-Step Proof Process</h1>
     <div class="method-single-box">
       <div class="method-single-box__header">
         <h3>FOUR-STEP PROOF</h3>


### PR DESCRIPTION
## Summary
- prefix the About page hero heading with its About navigation label
- update the Action guide headline to begin with the Action navigation label
- align the Method page heading with the Method navigation label

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ceff28100483309d10ac6047ccdafd