### PR TITLE
Adjust About page heading hierarchy

### DIFF
--- a/about/index.njk
+++ b/about/index.njk
@@ -12,14 +12,14 @@ permalink: /about/
 
     <p>We tried working within the system. As Democrats in West Virginia, we filed grievances, raised concerns, and followed proper channels when we witnessed corruption and misconduct. Time after time, our individual efforts were dismissed, isolated, and quietly buried.</p>
 
-    <h3>The Power of Proof</h3>
+    <h2>The Power of Proof</h2>
     <p>One person pointing out wrongdoing gets ignored. But a unified group with documented evidence cannot be dismissed so easily.</p>
 
     <p>Democratic Justice tackles what we believe holds West Virginia back: the lack of organized, fact-based accountability. We use a clear four-step method to build our cases. By focusing on evidence over emotion, we create an unshakeable foundation that others can rally behind.</p>
 
     <!-- Hobbes callout (inside the same align-container) -->
     <aside class="context-note brand" id="proofs-context" aria-labelledby="context-title">
-      <h3 id="context-title">Why “proof” matters in politics</h3>
+      <h2 id="context-title">Why “proof” matters in politics</h2>
       <p>In 1651, Thomas Hobbes built his argument for government like a mathematician builds a proof. Clear premises and visible steps lead to logical conclusions. We follow the same principle: show your work, trace your reasoning, let the facts speak. That's how real accountability begins.</p>
     </aside>
 

--- a/style.css
+++ b/style.css
@@ -1606,7 +1606,7 @@ html { scroll-behavior: smooth; }
   margin: var(--space-4) 0;
 }
 
-#about-page .context-note h3 {
+#about-page .context-note h2 {
   display: flex;
   align-items: center;
   gap: var(--space-2);
@@ -1628,7 +1628,7 @@ html { scroll-behavior: smooth; }
     border-color: var(--border-strong);
     border-left-color: var(--brand);
   }
-  #about-page .context-note h3 { color: var(--text); }
+  #about-page .context-note h2 { color: var(--text); }
   #about-page .context-note p { color: var(--text-soft); }
 }
 


### PR DESCRIPTION
## Summary
- promote the About page content sections to `<h2>` elements for a clearer heading cascade
- update the callout heading styles to match the new markup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf3f3a1c708330bc2acbdbe04bc37c