### PR TITLE
Integrate Pagefind search and log analytics

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -36,6 +36,9 @@
   <!-- Root-relative assets (safe from any page depth and pathPrefix-aware) -->
   <link rel="icon" href="{{ '/images/three-dots-blue.svg' | url }}" type="image/svg+xml">
   <link rel="stylesheet" href="{{ '/style.css' | url }}">
+  {% if pagefind %}
+  <link rel="stylesheet" href="{{ '/pagefind/pagefind-ui.css' | url }}">
+  {% endif %}
 
   <script type="application/ld+json">
     {
@@ -143,6 +146,10 @@
   </footer>
 
   <script defer src="/ga-consent.js"></script>
+  {% if pagefind %}
+  <script defer src="{{ '/pagefind/pagefind.js' | url }}"></script>
+  <script defer src="{{ '/pagefind/pagefind-ui.js' | url }}"></script>
+  {% endif %}
   <!-- Defer so it doesn't block rendering -->
   <script defer src="{{ '/bundle.js' | url }}"></script>
 

--- a/archive.njk
+++ b/archive.njk
@@ -3,6 +3,7 @@ layout: layout.njk
 title: Democratic Justice Proof Archive
 description: Explore the Democratic Justice proof archive highlighting documented evidence for West Virginia Democrats seeking accountability.
 permalink: "/archive/index.html"
+pagefind: true
 ---
 <div class="content-page" style="background: var(--paper);">
   <div class="align-container">

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,11 @@
+[build]
+  command = "npm run build"
+  publish = "_site"
+
+[dev]
+  command = "npm run dev"
+  port = 8888
+  autoLaunch = false
+
+[functions]
+  directory = "netlify/functions"

--- a/netlify/functions/log-search.js
+++ b/netlify/functions/log-search.js
@@ -1,0 +1,171 @@
+const buildResponse = (statusCode, payload) => ({
+  statusCode,
+  headers: {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS'
+  },
+  body: JSON.stringify(payload)
+});
+
+const sanitizeString = (value, maxLength = 512) => {
+  if (typeof value !== 'string') {
+    if (value === undefined || value === null) {
+      return '';
+    }
+    try {
+      value = String(value);
+    } catch (error) {
+      return '';
+    }
+  }
+
+  return value.slice(0, maxLength);
+};
+
+const toNumberOrNull = (value) => {
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+};
+
+const toIsoTimestamp = (value) => {
+  if (!value) {
+    return new Date().toISOString();
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? new Date().toISOString() : date.toISOString();
+};
+
+const submitToNetlifyForms = async (formId, token, payload) => {
+  const response = await fetch(`https://api.netlify.com/api/v1/forms/${formId}/submissions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify({
+      fields: payload,
+      metadata: {
+        source: 'archive-search'
+      }
+    })
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Netlify Forms responded with ${response.status}: ${errorText}`);
+  }
+
+  try {
+    return await response.json();
+  } catch (error) {
+    return { status: 'ok' };
+  }
+};
+
+const postToWebhook = async (url, payload) => {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Webhook responded with ${response.status}: ${text}`);
+  }
+
+  return { status: 'ok' };
+};
+
+export const handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 204,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'Content-Type',
+        'Access-Control-Allow-Methods': 'POST, OPTIONS'
+      },
+      body: ''
+    };
+  }
+
+  if (event.httpMethod !== 'POST') {
+    return buildResponse(405, { error: 'Method Not Allowed' });
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(event.body || '{}');
+  } catch (error) {
+    return buildResponse(400, { error: 'Invalid JSON payload' });
+  }
+
+  const query = sanitizeString(payload.query).trim();
+  if (!query) {
+    return buildResponse(400, { error: 'Missing search query' });
+  }
+
+  const results = toNumberOrNull(payload.results);
+  const pagefindResults = toNumberOrNull(payload.pagefindResults);
+  const strategy = sanitizeString(payload.strategy || 'unknown', 32);
+  const triggeredAt = toIsoTimestamp(payload.triggeredAt);
+  const filters = (payload.filters && typeof payload.filters === 'object') ? payload.filters : {};
+
+  const entry = {
+    query,
+    results,
+    pagefindResults,
+    strategy,
+    filters,
+    triggeredAt,
+    userAgent: sanitizeString(event.headers?.['user-agent'] || ''),
+    referer: sanitizeString(event.headers?.referer || event.headers?.referrer || '')
+  };
+
+  const attempts = [];
+  const webhookUrl = sanitizeString(process.env.SEARCH_LOG_WEBHOOK || '');
+  if (webhookUrl) {
+    try {
+      await postToWebhook(webhookUrl, entry);
+      attempts.push({ target: 'webhook', success: true });
+    } catch (error) {
+      console.error('Search log webhook submission failed', error);
+      attempts.push({ target: 'webhook', success: false, message: error.message });
+    }
+  }
+
+  const formId = sanitizeString(process.env.SEARCH_LOG_FORM_ID || '');
+  const accessToken = sanitizeString(process.env.NETLIFY_ACCESS_TOKEN || '');
+  if (formId && accessToken) {
+    try {
+      const response = await submitToNetlifyForms(formId, accessToken, entry);
+      attempts.push({ target: 'netlify-forms', success: true, response });
+    } catch (error) {
+      console.error('Netlify Forms submission failed', error);
+      attempts.push({ target: 'netlify-forms', success: false, message: error.message });
+    }
+  }
+
+  if (!attempts.length) {
+    console.warn('Search log received but no storage target configured.');
+    return buildResponse(202, { stored: false, reason: 'No storage target configured' });
+  }
+
+  const successful = attempts.some((attempt) => attempt.success);
+  const statusCode = successful ? 200 : 502;
+
+  return buildResponse(statusCode, {
+    stored: successful,
+    attempts
+  });
+};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "eleventy --serve",
     "build:js": "esbuild src/main.js --bundle --minify --outfile=bundle.js",
     "build:css": "postcss _site/style.css -o _site/style.css",
-    "build": "npm run build:js && eleventy && npm run build:css",
+    "build": "npm run build:js && eleventy && npm run build:css && npx pagefind --source _site",
     "test": "playwright test",
     "test:dark": "playwright test tests/dark-mode.spec.js",
     "test:browsers": "playwright install --with-deps"
@@ -25,6 +25,7 @@
     "@playwright/test": "^1.44.1",
     "autoprefixer": "^10.4.21",
     "cssnano": "^7.1.1",
+    "pagefind": "^1.4.0",
     "esbuild": "^0.21.0",
     "luxon": "^3.7.2",
     "postcss": "^8.5.6",


### PR DESCRIPTION
## Summary
- add Pagefind to the Eleventy build and gate its assets behind per-page front matter
- extend the archive navigation script to use Pagefind results and post search analytics to a Netlify Function
- add a Netlify Function and configuration for forwarding search logs to Forms or an external webhook

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf46bc53cc8330988d39cddeb41be5