### PR TITLE
Allow Microsoft Clarity embed customization

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -158,5 +158,67 @@
   <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "{{ env.CLOUDFLARE_ANALYTICS_TOKEN }}"}'></script>
   {%- endif -%}
 
+  {%- if env.MICROSOFT_CLARITY_PROJECT_ID -%}
+  <script type="text/javascript">
+    window.democraticJustice = window.democraticJustice || {};
+
+    window.democraticJustice.loadClarity = window.democraticJustice.loadClarity || function loadClarity() {
+      if (window.democraticJustice.clarityLoaded) {
+        return;
+      }
+
+      window.democraticJustice.clarityLoaded = true;
+
+      var defaultSettings = {
+        mask: true,
+        maskText: true,
+        maskImages: true
+      };
+      var customSettings = window.democraticJustice.claritySettings;
+      if (!customSettings || typeof customSettings !== "object") {
+        customSettings = {};
+      }
+      var combinedSettings = {};
+
+      for (var key in defaultSettings) {
+        if (Object.prototype.hasOwnProperty.call(defaultSettings, key)) {
+          combinedSettings[key] = defaultSettings[key];
+        }
+      }
+
+      for (var customKey in customSettings) {
+        if (Object.prototype.hasOwnProperty.call(customSettings, customKey)) {
+          combinedSettings[customKey] = customSettings[customKey];
+        }
+      }
+
+      window.claritySettings = combinedSettings;
+
+      (function (c, l, a, r, i, t, y) {
+        c[a] = c[a] || function () {
+          (c[a].q = c[a].q || []).push(arguments);
+        };
+        t = l.createElement(r);
+        t.async = 1;
+        t.type = "text/javascript";
+        t.src = "https://www.clarity.ms/tag/" + i;
+
+        var scriptAttributes = window.democraticJustice.clarityScriptAttrs;
+        if (!scriptAttributes || typeof scriptAttributes !== "object") {
+          scriptAttributes = {};
+        }
+        for (var attr in scriptAttributes) {
+          if (Object.prototype.hasOwnProperty.call(scriptAttributes, attr)) {
+            t.setAttribute(attr, scriptAttributes[attr]);
+          }
+        }
+
+        y = l.getElementsByTagName(r)[0];
+        y.parentNode.insertBefore(t, y);
+      })(window, document, "clarity", "script", "{{ env.MICROSOFT_CLARITY_PROJECT_ID }}");
+    };
+  </script>
+  {%- endif -%}
+
 </body>
 </html>

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -5,6 +5,12 @@
 2. Generate a beacon token and add it as the environment variable `CLOUDFLARE_ANALYTICS_TOKEN` in the deployment platform (e.g. Netlify).
 3. The site layout automatically injects the Cloudflare beacon when the token is present.
 
+## Microsoft Clarity
+1. Create a project in [Microsoft Clarity](https://clarity.microsoft.com/). The Clarity dashboard shows the project ID in the **Settings → Setup** section.
+2. Store the ID as the environment variable `MICROSOFT_CLARITY_PROJECT_ID` in your hosting platform rather than committing it to source control. For Netlify, run `netlify env:set MICROSOFT_CLARITY_PROJECT_ID <your-project-id>` or add the value via the Site settings UI.
+3. Deployments automatically receive the environment variable and the layout embeds the Clarity script only when the ID is present and the visitor has granted analytics consent.
+4. The embedded loader defers to the official snippet from the Clarity dashboard once consent is granted. It applies masked-session defaults by setting `mask`, `maskText`, and `maskImages` to `true`; override them by assigning `window.democraticJustice.claritySettings` before the analytics consent script runs. If you need extra tag attributes (for example a `nonce`), provide them through `window.democraticJustice.clarityScriptAttrs`.
+
 ## Alerts
 - In the Cloudflare dashboard open **Analytics → Alerts**.
 - Create notifications for request spikes or 5xx error rates according to your thresholds.

--- a/ga-consent.js
+++ b/ga-consent.js
@@ -15,9 +15,22 @@
     gtag('config', GA_ID, { anonymize_ip: true });
   }
 
+  function loadClarity() {
+    const namespace = window.democraticJustice || window.DemocraticJustice;
+    if (!namespace) {
+      return;
+    }
+
+    const clarityLoader = typeof namespace.loadClarity === 'function' ? namespace.loadClarity : null;
+    if (clarityLoader) {
+      clarityLoader();
+    }
+  }
+
   const consent = localStorage.getItem('analytics-consent');
   if (consent === 'granted') {
     loadGA();
+    loadClarity();
   } else if (consent !== 'denied') {
     const banner = document.createElement('div');
     banner.id = 'consent-banner';
@@ -28,6 +41,7 @@
       localStorage.setItem('analytics-consent','granted');
       banner.remove();
       loadGA();
+      loadClarity();
     });
     document.getElementById('consent-reject').addEventListener('click', function(){
       localStorage.setItem('analytics-consent','denied');


### PR DESCRIPTION
## Summary
- add an inline Microsoft Clarity loader that respects analytics consent and only renders when the project ID environment variable is set
- document how to supply the Clarity project ID through deployment environment settings while keeping the value out of source control
- allow optional customization of Clarity masking defaults and script attributes before consent triggers the official snippet

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf4a25df1c8330afb9c30f95f1d4fb