### PR TITLE
Add intent-specific Eleventy collections and landing pages

### DIFF
--- a/_includes/bottom-nav.html
+++ b/_includes/bottom-nav.html
@@ -2,6 +2,9 @@
   <ul class="bottom-nav-links">
     <li><a href="{{ '/' | url }}" aria-label="Home"{% if homeActive %} aria-current="page" class="is-active"{% endif %}>Home</a></li>
     <li><a href="{{ '/archive/' | url }}"{% if proofActive %} aria-current="page" class="is-active"{% endif %}>Proof</a></li>
+    <li><a href="{{ '/case-studies/' | url }}"{% if caseStudiesActive %} aria-current="page" class="is-active"{% endif %}>Case Studies</a></li>
+    <li><a href="{{ '/guides/' | url }}"{% if guidesActive %} aria-current="page" class="is-active"{% endif %}>Guides</a></li>
+    <li><a href="{{ '/troubleshooting/' | url }}"{% if troubleshootingActive %} aria-current="page" class="is-active"{% endif %}>Troubleshooting</a></li>
     <li><a href="{{ '/archive/#search-input' | url }}" data-search-link aria-label="Search proofs">Search</a></li>
     <li><a href="{{ '/method/' | url }}"{% if methodActive %} aria-current="page" class="is-active"{% endif %}>Method</a></li>
     <li><a href="{{ '/action/' | url }}"{% if actionActive %} aria-current="page" class="is-active"{% endif %}>Action</a></li>

--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -71,6 +71,9 @@
   {% set proofActive = currentUrl == '/archive/' or currentUrl == '/archive/index.html' or currentUrl.startsWith('/proofs/') %}
   {% set methodActive = currentUrl == '/method/' or currentUrl == '/method/index.html' %}
   {% set actionActive = currentUrl == '/action/' or currentUrl == '/action/index.html' or currentUrl.startsWith('/action/') %}
+  {% set guidesActive = currentUrl == '/guides/' or currentUrl == '/guides/index.html' %}
+  {% set troubleshootingActive = currentUrl == '/troubleshooting/' or currentUrl == '/troubleshooting/index.html' %}
+  {% set caseStudiesActive = currentUrl == '/case-studies/' or currentUrl == '/case-studies/index.html' %}
   {% set aboutActive = currentUrl == '/about/' or currentUrl == '/about/index.html' %}
   {% set contactActive = currentUrl == '/contact/' or currentUrl == '/contact/index.html' %}
   {% set submitActive = currentUrl == '/submit/' or currentUrl == '/submit/index.html' %}
@@ -99,6 +102,9 @@
         <ul class="nav-links" id="primary-nav">
           <li><a href="{{ '/archive/' | url }}"{% if proofActive %} class="is-active" aria-current="page"{% endif %}>Proof</a></li>
           <li class="nav-item-search"><a href="{{ '/archive/#search-input' | url }}" data-search-link aria-label="Search proofs">Search</a></li>
+          <li><a href="{{ '/case-studies/' | url }}"{% if caseStudiesActive %} class="is-active" aria-current="page"{% endif %}>Case Studies</a></li>
+          <li><a href="{{ '/guides/' | url }}"{% if guidesActive %} class="is-active" aria-current="page"{% endif %}>Guides</a></li>
+          <li><a href="{{ '/troubleshooting/' | url }}"{% if troubleshootingActive %} class="is-active" aria-current="page"{% endif %}>Troubleshooting</a></li>
           <li><a href="{{ '/method/' | url }}"{% if methodActive %} class="is-active" aria-current="page"{% endif %}>Method</a></li>
           <li><a href="{{ '/action/' | url }}"{% if actionActive %} class="is-active" aria-current="page"{% endif %}>Action</a></li>
           <li><a href="{{ '/about/' | url }}"{% if aboutActive %} class="is-active" aria-current="page"{% endif %}>About</a></li>

--- a/action/file.njk
+++ b/action/file.njk
@@ -3,6 +3,11 @@ layout: layout.njk
 title: "Challenge Review Intake — Democratic Justice"
 description: "Request a Democratic Justice challenge review to confirm standing, deadlines, and filing steps before you submit."
 permalink: /action/file/
+intent: guide
+tasks:
+  - filing
+  - support
+intentOrder: 2
 ---
 
 <section class="content-page" id="challenge-review-page">

--- a/action/index.njk
+++ b/action/index.njk
@@ -3,6 +3,11 @@ layout: layout.njk
 title: "Take Action: A Guide to Filing Grievances - Democratic Justice"
 description: "A focused guide for West Virginia Democrats on how to file common grievances and escalate to the DNC if necessary."
 permalink: /action/
+intent: guide
+tasks:
+  - filing
+  - grievance-process
+intentOrder: 1
 ---
 
 <section class="content-page" id="action-page">

--- a/case-studies.njk
+++ b/case-studies.njk
@@ -1,0 +1,45 @@
+---
+layout: layout.njk
+title: "Case Studies - Democratic Justice"
+description: "Explore Democratic Justice case studies that group proofs by umbrella findings and show where action is needed."
+permalink: /case-studies/
+---
+
+<section class="content-page" id="case-studies-page">
+  <div class="align-container">
+    <p class="section-label">Case Studies</p>
+    <h1>Case Studies from the Proof Archive</h1>
+    <p class="lead">Dive into umbrella findings that assemble individual proofs, highlight violations, and document the supporting evidence.</p>
+
+    {% set studies = collections.caseStudies %}
+    {% if studies and studies | length %}
+    <div class="resource-list" role="list">
+      {% for study in studies %}
+      {% set overproofGroup = study.data.overproofGroup %}
+      {% set overproof = overproofGroup.overproof %}
+      {% set studyTitle = (overproof.brief and overproof.brief.headline) or overproof.short_title or overproof.title %}
+      {% set studySummary = study.data.description or (overproof.brief and overproof.brief.lede) or overproof.summary %}
+      {% set proofCount = overproof.proofCount or (overproofGroup.proofs | length) %}
+      <article class="resource-card" role="listitem">
+        <h2><a href="{{ study.url | url }}">{{ studyTitle }}</a></h2>
+        {% if studySummary %}
+        <p>{{ studySummary }}</p>
+        {% endif %}
+        {% if proofCount %}
+        <p class="resource-card__meta">{{ proofCount }} proof{% if proofCount != 1 %}s{% endif %} documented</p>
+        {% endif %}
+        {% if study.data.tasks and study.data.tasks | length %}
+        <ul class="resource-card__tasks">
+          {% for task in study.data.tasks %}
+          <li>{{ task | replace('-', ' ') | capitalize }}</li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+      </article>
+      {% endfor %}
+    </div>
+    {% else %}
+    <p>No case studies are published yet. Check back soon.</p>
+    {% endif %}
+  </div>
+</section>

--- a/docs/dark-mode-testing.md
+++ b/docs/dark-mode-testing.md
@@ -1,3 +1,15 @@
+---
+layout: layout.njk
+title: "Dark Mode Regression Testing"
+description: "Verify the dark theme with DOM-level Playwright assertions instead of screenshots."
+intent: guide
+tasks:
+  - testing
+  - qa
+permalink: /docs/dark-mode-testing/
+intentOrder: 4
+---
+
 # Dark Mode Regression Testing
 
 The dark theme is now verified with DOM-level assertions instead of screenshot comparisons. The Playwright spec at `tests/dark-mode.spec.js` loads the homepage with the dark theme enabled and inspects computed styles for critical UI regions.

--- a/docs/image-workflow.md
+++ b/docs/image-workflow.md
@@ -1,3 +1,15 @@
+---
+layout: layout.njk
+title: "Image Workflow"
+description: "Use the Eleventy image shortcode to generate responsive assets and optimized formats."
+intent: guide
+tasks:
+  - tooling
+  - assets
+permalink: /docs/image-workflow/
+intentOrder: 3
+---
+
 # Image Workflow
 
 This project uses the Eleventy Image utility (`@11ty/eleventy-img`) through a global `image` Nunjucks shortcode to generate responsive `<picture>` markup with AVIF, WebP, and raster fallbacks.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,3 +1,15 @@
+---
+layout: layout.njk
+title: "Monitoring and Backups"
+description: "Configure analytics, alerts, and scheduled backups so site operations stay resilient."
+intent: troubleshooting
+tasks:
+  - operations
+  - observability
+permalink: /docs/monitoring/
+intentOrder: 1
+---
+
 # Monitoring and Backups
 
 ## Cloudflare Web Analytics

--- a/guides.njk
+++ b/guides.njk
@@ -1,0 +1,37 @@
+---
+layout: layout.njk
+title: "Guides - Democratic Justice"
+description: "Step-by-step guidance for filing grievances and using the Democratic Justice toolkit."
+permalink: /guides/
+---
+
+<section class="content-page" id="guides-page">
+  <div class="align-container">
+    <p class="section-label">Guides</p>
+    <h1>Guides for Organizers and Filers</h1>
+    <p class="lead">Structured walkthroughs covering formal grievance filings, contributor workflows, and the project tooling.</p>
+
+    {% set guides = collections.guides %}
+    {% if guides and guides | length %}
+    <div class="resource-list" role="list">
+      {% for guide in guides %}
+      <article class="resource-card" role="listitem">
+        <h2><a href="{{ guide.url | url }}">{{ guide.data.title }}</a></h2>
+        {% if guide.data.description %}
+        <p>{{ guide.data.description }}</p>
+        {% endif %}
+        {% if guide.data.tasks and guide.data.tasks | length %}
+        <ul class="resource-card__tasks">
+          {% for task in guide.data.tasks %}
+          <li>{{ task | replace('-', ' ') | capitalize }}</li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+      </article>
+      {% endfor %}
+    </div>
+    {% else %}
+    <p>No guides are published yet. Check back soon.</p>
+    {% endif %}
+  </div>
+</section>

--- a/overproof.njk
+++ b/overproof.njk
@@ -5,6 +5,10 @@ pagination:
   size: 1
   alias: overproofGroup
 permalink: "proofs/{{ overproofGroup.overproof.slug }}/index.html"
+intent: case-study
+tasks:
+  - proof-record
+  - precedent
 eleventyComputed:
   title: "{{ (overproofGroup.overproof.brief and overproofGroup.overproof.brief.headline) or overproofGroup.overproof.title }} — Proof Record"
   description: "{{ (overproofGroup.overproof.brief and overproofGroup.overproof.brief.lede) or overproofGroup.overproof.summary }}"

--- a/style.css
+++ b/style.css
@@ -1438,6 +1438,61 @@ p{
 /* Section wrapper padding (all breakpoints) */
 .content-page { padding: calc(var(--space-8) + var(--space-6)) 0; }
 
+.resource-list {
+  display: grid;
+  gap: var(--space-5);
+  margin-top: var(--space-6);
+}
+
+@media (min-width:768px) {
+  .resource-list {
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  }
+}
+
+.resource-card {
+  background: var(--paper-light);
+  border-radius: 12px;
+  padding: var(--space-5);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.resource-card h2 {
+  margin: 0;
+}
+
+.resource-card p {
+  margin: 0;
+}
+
+.resource-card__meta {
+  font-size: var(--font-size-sm);
+  color: var(--muted);
+}
+
+.resource-card__tasks {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+}
+
+.resource-card__tasks li {
+  background: var(--color-interactive-neutral);
+  color: var(--color-text-base);
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
 /* Overproof record */
 .overproof-narrative{
   margin-bottom:var(--space-6);

--- a/troubleshooting.njk
+++ b/troubleshooting.njk
@@ -1,0 +1,37 @@
+---
+layout: layout.njk
+title: "Troubleshooting - Democratic Justice"
+description: "Operational runbooks and analytics triage notes for Democratic Justice maintainers."
+permalink: /troubleshooting/
+---
+
+<section class="content-page" id="troubleshooting-page">
+  <div class="align-container">
+    <p class="section-label">Troubleshooting</p>
+    <h1>Troubleshooting and Operations Playbooks</h1>
+    <p class="lead">Resolve analytics configuration, monitoring gaps, and deployment issues with focused instructions.</p>
+
+    {% set issues = collections.troubleshooting %}
+    {% if issues and issues | length %}
+    <div class="resource-list" role="list">
+      {% for issue in issues %}
+      <article class="resource-card" role="listitem">
+        <h2><a href="{{ issue.url | url }}">{{ issue.data.title }}</a></h2>
+        {% if issue.data.description %}
+        <p>{{ issue.data.description }}</p>
+        {% endif %}
+        {% if issue.data.tasks and issue.data.tasks | length %}
+        <ul class="resource-card__tasks">
+          {% for task in issue.data.tasks %}
+          <li>{{ task | replace('-', ' ') | capitalize }}</li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+      </article>
+      {% endfor %}
+    </div>
+    {% else %}
+    <p>No troubleshooting guides are available yet. Check back soon.</p>
+    {% endif %}
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- tag guidance, troubleshooting, and case-study content with new intent metadata and ordering fields
- add helper utilities and Eleventy collections that filter entries by intent for guides, troubleshooting, and case studies
- create dedicated landing pages with navigation and styling updates for each intent-driven collection

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf552824f483309f0de493f0251545