### PR TITLE
Remove analytics consent banner for GoatCounter

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,6 +1,6 @@
 /*
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://www.googletagmanager.com; object-src 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://gc.zgo.at; object-src 'none'; base-uri 'self'
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: no-referrer

--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -30,8 +30,6 @@
   <link rel="preload" as="font" href="https://fonts.gstatic.com/s/oswald/v57/TK3_WkUHHAIjg75cFRf3bXL8LICs1y9ogUE.ttf" type="font/ttf" crossorigin>
   <link rel="preload" as="font" href="https://fonts.gstatic.com/s/oswald/v57/TK3_WkUHHAIjg75cFRf3bXL8LICs1xZogUE.ttf" type="font/ttf" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Oswald:wght@600;700&display=swap">
-  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
-  <link rel="dns-prefetch" href="https://www.googletagmanager.com">
 
   <!-- Root-relative assets (safe from any page depth and pathPrefix-aware) -->
   <link rel="icon" href="{{ '/images/three-dots-blue.svg' | url }}" type="image/svg+xml">

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -12,6 +12,11 @@ intentOrder: 1
 
 # Monitoring and Backups
 
+## GoatCounter
+- Page views are tracked with [GoatCounter](https://www.goatcounter.com/). The script is configured to send hits to `https://democraticjustice.goatcounter.com/count`.
+- GoatCounter does not set cookies for visitors, so the analytics loader runs automatically without a consent banner.
+- To point to a different GoatCounter instance, update the URL constants in `ga-consent.js`.
+
 ## Cloudflare Web Analytics
 1. Create a site in [Cloudflare Web Analytics](https://www.cloudflare.com/web-analytics/).
 2. Generate a beacon token and add it as the environment variable `CLOUDFLARE_ANALYTICS_TOKEN` in the deployment platform (e.g. Netlify).
@@ -20,8 +25,8 @@ intentOrder: 1
 ## Microsoft Clarity
 1. Create a project in [Microsoft Clarity](https://clarity.microsoft.com/). The Clarity dashboard shows the project ID in the **Settings → Setup** section.
 2. Store the ID as the environment variable `MICROSOFT_CLARITY_PROJECT_ID` in your hosting platform rather than committing it to source control. For Netlify, run `netlify env:set MICROSOFT_CLARITY_PROJECT_ID <your-project-id>` or add the value via the Site settings UI.
-3. Deployments automatically receive the environment variable and the layout embeds the Clarity script only when the ID is present and the visitor has granted analytics consent.
-4. The embedded loader defers to the official snippet from the Clarity dashboard once consent is granted. It applies masked-session defaults by setting `mask`, `maskText`, and `maskImages` to `true`; override them by assigning `window.democraticJustice.claritySettings` before the analytics consent script runs. If you need extra tag attributes (for example a `nonce`), provide them through `window.democraticJustice.clarityScriptAttrs`.
+3. Deployments automatically receive the environment variable and the layout embeds the Clarity script only when the ID is present.
+4. The embedded loader defers to the official snippet from the Clarity dashboard. It applies masked-session defaults by setting `mask`, `maskText`, and `maskImages` to `true`; override them by assigning `window.democraticJustice.claritySettings` before the analytics loader runs. If you need extra tag attributes (for example a `nonce`), provide them through `window.democraticJustice.clarityScriptAttrs`.
 
 ## Alerts
 - In the Cloudflare dashboard open **Analytics → Alerts**.

--- a/ga-consent.js
+++ b/ga-consent.js
@@ -1,18 +1,18 @@
 (function () {
-  const GA_ID = 'G-3TV2GBS34Y';
+  const GOATCOUNTER_COUNT_URL = 'https://democraticjustice.goatcounter.com/count';
+  const GOATCOUNTER_SCRIPT_SRC = 'https://gc.zgo.at/count.js';
 
-  function loadGA() {
-    if (window.dataLayer) return;
-    const gtagScript = document.createElement('script');
-    gtagScript.src = `https://www.googletagmanager.com/gtag/js?id=${GA_ID}`;
-    gtagScript.async = true;
-    document.head.appendChild(gtagScript);
+  function loadGoatCounter() {
+    if (document.querySelector('script[data-goatcounter]')) {
+      return;
+    }
 
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    window.gtag = gtag;
-    gtag('js', new Date());
-    gtag('config', GA_ID, { anonymize_ip: true });
+    const goatcounterScript = document.createElement('script');
+    goatcounterScript.async = true;
+    goatcounterScript.src = GOATCOUNTER_SCRIPT_SRC;
+    goatcounterScript.setAttribute('data-goatcounter', GOATCOUNTER_COUNT_URL);
+
+    (document.body || document.head || document.documentElement).appendChild(goatcounterScript);
   }
 
   function loadClarity() {
@@ -27,25 +27,14 @@
     }
   }
 
-  const consent = localStorage.getItem('analytics-consent');
-  if (consent === 'granted') {
-    loadGA();
+  function init() {
+    loadGoatCounter();
     loadClarity();
-  } else if (consent !== 'denied') {
-    const banner = document.createElement('div');
-    banner.id = 'consent-banner';
-    banner.style.cssText = 'position:fixed;bottom:0;left:0;right:0;background:#eee;padding:1em;text-align:center;z-index:1000;';
-    banner.innerHTML = '<span>We use cookies for analytics.</span> <button id="consent-accept">Accept</button> <button id="consent-reject">Reject</button>';
-    document.body.appendChild(banner);
-    document.getElementById('consent-accept').addEventListener('click', function(){
-      localStorage.setItem('analytics-consent','granted');
-      banner.remove();
-      loadGA();
-      loadClarity();
-    });
-    document.getElementById('consent-reject').addEventListener('click', function(){
-      localStorage.setItem('analytics-consent','denied');
-      banner.remove();
-    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
   }
 })();

--- a/privacy.njk
+++ b/privacy.njk
@@ -1,17 +1,17 @@
 ---
 layout: layout.njk
 title: "Privacy Policy — Democratic Justice"
-description: "How we handle your data and cookies."
+description: "How we handle your data and analytics."
 permalink: /privacy/
-reviewDate: 2024-12-01
+reviewDate: 2025-09-22
 ---
 
 <section class="content-page" id="privacy-page">
   <div class="align-container">
     <h1>Privacy Policy</h1>
-    <p>We collect only the information needed to operate this site. A small cookie stored in your browser remembers whether you have granted consent for analytics.</p>
-    <p>Analytics are provided by Google Analytics. Data is anonymized and used to understand aggregate site usage so we can improve content. No personal information is sold or shared for marketing purposes.</p>
-    <p>You can change your consent at any time by clearing your browser's local storage or using a different browser or device.</p>
+    <p>We collect only the information needed to operate this site. GoatCounter provides our privacy-friendly analytics and does not write cookies or personal data to your browser.</p>
+    <p>When session insights are enabled, Microsoft Clarity records anonymized interaction data with masking turned on for text, images, and other potentially sensitive content. We use these aggregate patterns to improve the site.</p>
+    <p>No personal information is sold or shared for marketing purposes.</p>
     <p>For questions, contact <a href="mailto:setho@democraticjustice.org">setho@democraticjustice.org</a>.</p>
     <p>This policy may be updated from time to time. Check this page for the latest information.</p>
   </div>


### PR DESCRIPTION
## Summary
- automatically load GoatCounter and Clarity without the previous consent banner
- refresh the privacy policy to describe GoatCounter analytics and masked Clarity sessions
- document the GoatCounter setup and remove consent references from the monitoring guide

## Testing
- npm run build:js

------
https://chatgpt.com/codex/tasks/task_e_68cf62b3ddd483308051ee3c41ffb722