### PR TITLE
Add HTML minification to Eleventy build

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -3,6 +3,7 @@ const { DateTime } = require("luxon");
 const Image = require("@11ty/eleventy-img");
 const fs = require("node:fs/promises");
 const path = require("node:path");
+const htmlMinifier = require("html-minifier-terser");
 const slugifyImport = require("@sindresorhus/slugify");
 const slugifyFn = typeof slugifyImport === "function" ? slugifyImport : slugifyImport?.default;
 
@@ -843,6 +844,26 @@ module.exports = function(eleventyConfig) {
 
   eleventyConfig.on("beforeBuild", () => {
     cachedProofCollections = null;
+  });
+
+  eleventyConfig.addTransform("htmlmin", async (content, outputPath) => {
+    if (typeof outputPath === "string" && outputPath.endsWith(".html")) {
+      try {
+        return await htmlMinifier.minify(content, {
+          collapseWhitespace: true,
+          removeComments: true,
+          useShortDoctype: true,
+          removeRedundantAttributes: true,
+          removeEmptyAttributes: true,
+          minifyJS: true,
+          minifyCSS: true
+        });
+      } catch (error) {
+        console.warn("HTML minification failed for", outputPath, error);
+      }
+    }
+
+    return content;
   });
 
   eleventyConfig.on("afterBuild", async () => {

--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
     "@playwright/test": "^1.44.1",
     "autoprefixer": "^10.4.21",
     "cssnano": "^7.1.1",
-    "pagefind": "^1.4.0",
     "esbuild": "^0.21.0",
+    "html-minifier-terser": "^7.2.0",
     "luxon": "^3.7.2",
+    "pagefind": "^1.4.0",
     "postcss": "^8.5.6",
     "postcss-cli": "^11.0.1"
   }


### PR DESCRIPTION
## Summary
- add html-minifier-terser as a dev dependency for Eleventy builds
- register an Eleventy transform to minify generated HTML output

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf6e5127f883308b4ac50707a3ed13