### PR TITLE
Render layout content safely

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -118,7 +118,7 @@
   </nav>
 
   <main id="main">
-    {{ content }}
+    {{ content | safe }}
   </main>
 
   {% if site.mobileNavBreakpoint %}


### PR DESCRIPTION
## Summary
- render the layout's main slot using the Eleventy `safe` filter so page markup is not escaped

## Testing
- npm run build *(fails: puppeteer cannot launch because Chromium is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f2663d2c8330a73abd910b44b5cf