### PR TITLE
Update navigation links in bottom nav and footer

### DIFF
--- a/_includes/bottom-nav.html
+++ b/_includes/bottom-nav.html
@@ -1,14 +1,8 @@
-<nav class="bottom-nav" aria-label="Primary">
+<nav class="bottom-nav" aria-label="Quick links">
   <ul class="bottom-nav-links">
-    <li><a href="{{ '/' | url }}" aria-label="Home"{% if homeActive %} aria-current="page" class="is-active"{% endif %}>Home</a></li>
-    <li><a href="{{ '/archive/' | url }}"{% if proofActive %} aria-current="page" class="is-active"{% endif %}>Proof</a></li>
-    <li><a href="{{ '/case-studies/' | url }}"{% if caseStudiesActive %} aria-current="page" class="is-active"{% endif %}>Case Studies</a></li>
-    <li><a href="{{ '/guides/' | url }}"{% if guidesActive %} aria-current="page" class="is-active"{% endif %}>Guides</a></li>
-    <li><a href="{{ '/troubleshooting/' | url }}"{% if troubleshootingActive %} aria-current="page" class="is-active"{% endif %}>Troubleshooting</a></li>
-    <li><a href="{{ '/archive/#search-input' | url }}" data-search-link aria-label="Search proofs">Search</a></li>
-    <li><a href="{{ '/method/' | url }}"{% if methodActive %} aria-current="page" class="is-active"{% endif %}>Method</a></li>
-    <li><a href="{{ '/action/' | url }}"{% if actionActive %} aria-current="page" class="is-active"{% endif %}>Action</a></li>
-    <li><a href="{{ '/contact/' | url }}"{% if contactActive %} aria-current="page" class="is-active"{% endif %}>Contact</a></li>
-    <li><a href="{{ '/submit/' | url }}"{% if submitActive %} aria-current="page" class="is-active"{% endif %}>Submit</a></li>
+    <li><a href="{{ '/archive/' | url }}"{% if proofActive %} aria-current="page" class="is-active"{% endif %}>Full Archive</a></li>
+    <li><a href="{{ '/about/' | url }}"{% if aboutActive %} aria-current="page" class="is-active"{% endif %}>About Us</a></li>
+    <li><a href="{{ '/case-studies/' | url }}"{% if caseStudiesActive %} aria-current="page" class="is-active"{% endif %}>Overproofs</a></li>
+    <li><a href="{{ '/submit/' | url }}"{% if submitActive %} aria-current="page" class="is-active"{% endif %}>Submit Proof</a></li>
   </ul>
 </nav>

--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -134,13 +134,31 @@
           sizes: "200px"
         } %}
       </div>
-      <p><strong>Proof. Not Spin.</strong></p>
-      <p>A 100% volunteer-run project. We do not solicit or accept financial contributions. We do not endorse candidates.</p>
-      <p><a href="mailto:setho@democraticjustice.org">Submit Proof Confidentially</a></p>
-      <p><a href="{{ '/integrity' | url }}">Proof of Integrity</a></p>
-      <p><a href="{{ '/privacy' | url }}">Privacy Policy</a></p>
-      <p>&copy; {{ now | date('%Y') }} Democratic Justice. All rights reserved.</p>
-
+      <div class="footer-grid">
+        <div class="footer-mission">
+          <p><strong>Proof. Not Spin.</strong></p>
+          <p>A 100% volunteer-run project. We do not solicit or accept financial contributions. We do not endorse candidates.</p>
+          <p><a href="mailto:setho@democraticjustice.org">Submit Proof Confidentially</a></p>
+          <p><a href="{{ '/integrity' | url }}">Proof of Integrity</a></p>
+          <p><a href="{{ '/privacy' | url }}">Privacy Policy</a></p>
+          <p>&copy; {{ now | date('%Y') }} Democratic Justice. All rights reserved.</p>
+        </div>
+        <nav class="footer-nav" aria-label="Footer navigation">
+          <ul class="footer-nav__list">
+            <li><a href="{{ '/' | url }}">Home</a></li>
+            <li><a href="{{ '/archive/' | url }}">Proof Archive</a></li>
+            <li><a href="{{ '/archive/#search-input' | url }}" data-search-link>Search Proofs</a></li>
+            <li><a href="{{ '/case-studies/' | url }}">Overproofs</a></li>
+            <li><a href="{{ '/guides/' | url }}">Guides</a></li>
+            <li><a href="{{ '/troubleshooting/' | url }}">Troubleshooting</a></li>
+            <li><a href="{{ '/method/' | url }}">Method</a></li>
+            <li><a href="{{ '/action/' | url }}">Action</a></li>
+            <li><a href="{{ '/about/' | url }}">About Us</a></li>
+            <li><a href="{{ '/contact/' | url }}">Contact</a></li>
+            <li><a href="{{ '/submit/' | url }}">Submit Proof</a></li>
+          </ul>
+        </nav>
+      </div>
       <a href="{{ '/' | url }}" aria-label="Democratic Justice home">
         {% image "/images/three-dots-white.svg", "", {
           class: "mark xl",

--- a/style.css
+++ b/style.css
@@ -1245,7 +1245,7 @@ p{
 .footer strong{
   color:var(--white);
 }
-.footer a{
+.footer p a{
   color:var(--brand);
   font-weight:700;
   border-bottom:1px solid var(--brand);
@@ -1253,9 +1253,54 @@ p{
   align-items:center;
   gap: var(--space-2);
 }
-.footer a:hover{
+.footer p a:hover{
   background:var(--brand);
   color:var(--ink);
+}
+.footer-grid{
+  display:grid;
+  gap: var(--space-5);
+}
+@media (min-width:768px){
+  .footer-grid{
+    grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr);
+    align-items:flex-start;
+  }
+}
+.footer-mission p:last-of-type{
+  margin-bottom:0;
+}
+.footer-nav__list{
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:grid;
+  gap: var(--space-3);
+}
+@media (min-width:640px){
+  .footer-nav__list{
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
+}
+.footer-nav__list li{
+  margin:0;
+}
+.footer-nav__list a{
+  color:var(--color-text-on-primary);
+  font-weight:700;
+  font-size:var(--font-size-sm);
+  text-decoration:none;
+  display:inline-flex;
+  align-items:center;
+  gap: var(--space-2);
+  transition:color .2s ease;
+}
+.footer-nav__list a:hover{
+  color:var(--color-primary-200);
+}
+.footer-nav__list a:focus-visible{
+  outline:2px solid var(--color-focus-ring);
+  outline-offset:2px;
 }
 
 /* Modal */


### PR DESCRIPTION
## Summary
- trim the mobile bottom navigation to highlight the archive, about page, overproofs, and submit proof link
- reorganize the footer with a dedicated navigation list covering major site sections alongside the existing mission copy
- add layout and accessibility styles for the expanded footer navigation

## Testing
- PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 npm install
- npm run build *(fails: Puppeteer cannot download Chromium in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d15b5e352883308ab1df3406522a58