### PR TITLE
Ensure hero retains brand styling on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -703,15 +703,6 @@ p{
   z-index: -1;
 }
 
-@media (max-width:768px){
-  .hero{
-    background-color: var(--paper-light);
-    color: var(--text);
-  }
-  .hero-headline::after{
-    content: none;
-  }
-}
 
 /* Hero grid */
 .hero-grid{


### PR DESCRIPTION
## Summary
- remove the mobile override that changed the hero background and hid the mark so the branded navy treatment applies on all viewports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1776d92248330927d8efb97d3c88f