### PR TITLE
Refine primary navigation layout and labels

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -71,11 +71,9 @@
 
   {% set currentUrl = page.url or '/' %}
   {% set proofActive = currentUrl == '/archive/' or currentUrl == '/archive/index.html' or currentUrl.startsWith('/proofs/') %}
-  {% set methodActive = currentUrl == '/method/' or currentUrl == '/method/index.html' %}
   {% set actionActive = currentUrl == '/action/' or currentUrl == '/action/index.html' or currentUrl.startsWith('/action/') %}
   {% set caseStudiesActive = currentUrl == '/case-studies/' or currentUrl == '/case-studies/index.html' %}
   {% set aboutActive = currentUrl == '/about/' or currentUrl == '/about/index.html' %}
-  {% set contactActive = currentUrl == '/contact/' or currentUrl == '/contact/index.html' %}
   {% set submitActive = currentUrl == '/submit/' or currentUrl == '/submit/index.html' %}
   {% set homeActive = currentUrl == '/' or currentUrl == '/index.html' %}
 
@@ -103,11 +101,9 @@
           <li><a href="{{ '/archive/' | url }}"{% if proofActive %} class="is-active" aria-current="page"{% endif %}>Proof</a></li>
           <li class="nav-item-search"><a href="{{ '/archive/#search-input' | url }}" data-search-link aria-label="Search proofs">Search</a></li>
           <li><a href="{{ '/case-studies/' | url }}"{% if caseStudiesActive %} class="is-active" aria-current="page"{% endif %}>Case Studies</a></li>
-          <li><a href="{{ '/method/' | url }}"{% if methodActive %} class="is-active" aria-current="page"{% endif %}>Method</a></li>
-          <li><a href="{{ '/action/' | url }}"{% if actionActive %} class="is-active" aria-current="page"{% endif %}>Action</a></li>
+          <li><a href="{{ '/action/' | url }}"{% if actionActive %} class="is-active" aria-current="page"{% endif %}>Filing Guide</a></li>
           <li><a href="{{ '/about/' | url }}"{% if aboutActive %} class="is-active" aria-current="page"{% endif %}>About</a></li>
-          <li><a href="{{ '/contact/' | url }}"{% if contactActive %} class="is-active" aria-current="page"{% endif %}>Contact</a></li>
-          <li><a href="{{ '/submit/' | url }}" class="btn-nav-submit{% if submitActive %} is-active{% endif %}"{% if submitActive %} aria-current="page"{% endif %}>Submit</a></li>
+          <li><a href="{{ '/submit/' | url }}" class="btn-nav-submit{% if submitActive %} is-active{% endif %}"{% if submitActive %} aria-current="page"{% endif %}>Submit Proof</a></li>
         </ul>
       </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -567,7 +567,7 @@ p{
     right:auto;
     background:transparent;
     padding: 0;
-    gap: var(--space-5);
+    gap: clamp(var(--space-3), 2.5vw, var(--space-4));
     row-gap: var(--space-3);
     box-shadow:none;
     align-items:center;


### PR DESCRIPTION
## Summary
- replace the vague "Action" nav label with "Filing Guide" and rename the call-to-action to "Submit Proof"
- remove unnecessary Method and Contact nav items to streamline primary navigation
- tighten horizontal spacing between nav links for easier scanning on large screens

## Testing
- `npm run build` *(fails: critical CSS build step requires Chromium, which cannot be downloaded in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f62055e88330a1c3542f47e74ca4