### PR TITLE
Route primary proof navigation to overproof records

### DIFF
--- a/_includes/bottom-nav.html
+++ b/_includes/bottom-nav.html
@@ -1,6 +1,6 @@
 <nav class="bottom-nav" aria-label="Quick links">
   <ul class="bottom-nav-links">
-    <li><a href="{{ '/archive/' | url }}"{% if proofActive %} aria-current="page" class="is-active"{% endif %}>Full Archive</a></li>
+    <li><a href="{{ '/archive/' | url }}"{% if archiveActive %} aria-current="page" class="is-active"{% endif %}>Full Archive</a></li>
     <li><a href="{{ '/about/' | url }}"{% if aboutActive %} aria-current="page" class="is-active"{% endif %}>About Us</a></li>
     <li><a href="{{ '/case-studies/' | url }}"{% if caseStudiesActive %} aria-current="page" class="is-active"{% endif %}>Overproofs</a></li>
     <li><a href="{{ '/submit/' | url }}"{% if submitActive %} aria-current="page" class="is-active"{% endif %}>Submit Proof</a></li>

--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -70,12 +70,13 @@
 <body>
 
   {% set currentUrl = page.url or '/' %}
-  {% set proofActive = currentUrl == '/archive/' or currentUrl == '/archive/index.html' or currentUrl.startsWith('/proofs/') %}
+  {% set proofActive = currentUrl == '/case-studies/' or currentUrl == '/case-studies/index.html' or currentUrl.startsWith('/proofs/') %}
   {% set actionActive = currentUrl == '/action/' or currentUrl == '/action/index.html' or currentUrl.startsWith('/action/') %}
   {% set caseStudiesActive = currentUrl == '/case-studies/' or currentUrl == '/case-studies/index.html' %}
   {% set aboutActive = currentUrl == '/about/' or currentUrl == '/about/index.html' %}
   {% set submitActive = currentUrl == '/submit/' or currentUrl == '/submit/index.html' %}
   {% set homeActive = currentUrl == '/' or currentUrl == '/index.html' %}
+  {% set archiveActive = currentUrl == '/archive/' or currentUrl == '/archive/index.html' %}
 
   <a class="skip" href="#main">Skip to content</a>
 
@@ -98,7 +99,7 @@
           </svg>
         </button>
         <ul class="nav-links" id="primary-nav">
-          <li><a href="{{ '/archive/' | url }}"{% if proofActive %} class="is-active" aria-current="page"{% endif %}>Proof</a></li>
+          <li><a href="{{ '/case-studies/' | url }}"{% if proofActive %} class="is-active" aria-current="page"{% endif %}>Proof</a></li>
           <li class="nav-item-search"><a href="{{ '/archive/#search-input' | url }}" data-search-link aria-label="Search proofs">Search</a></li>
           <li><a href="{{ '/case-studies/' | url }}"{% if caseStudiesActive %} class="is-active" aria-current="page"{% endif %}>Case Studies</a></li>
           <li><a href="{{ '/action/' | url }}"{% if actionActive %} class="is-active" aria-current="page"{% endif %}>Filing Guide</a></li>

--- a/case.njk
+++ b/case.njk
@@ -37,7 +37,7 @@ eleventyComputed:
     <nav aria-label="Breadcrumb" class="breadcrumb">
       <ol>
         <li><a href="{{ '/' | url }}">Home</a></li>
-        <li><a href="{{ '/archive' | url }}">Proof</a></li>
+        <li><a href="{{ '/case-studies/' | url }}">Proof Record</a></li>
         {% if overproof %}
         <li><a href="{{ overproofUrl }}">{{ overproofLabel }}</a></li>
         {% endif %}
@@ -58,8 +58,8 @@ eleventyComputed:
           {
             "@type": "ListItem",
             "position": 2,
-            "name": "Proof",
-            "item": "{{ site.url }}{{ '/archive/' | url }}"
+            "name": "Proof Record",
+            "item": "{{ site.url }}{{ '/case-studies/' | url }}"
           }
           {% if overproof %}
           ,

--- a/index.njk
+++ b/index.njk
@@ -14,8 +14,8 @@ reviewDate: 2024-12-01
       <div>
         <h1 class="hero-headline">Proof.<strong>Not Spin.</strong></h1>
         <div class="btn-group">
-          <a href="{{ '/archive' | url }}" class="btn btn-accent">
-            See the Proof
+          <a href="{{ '/case-studies/' | url }}" class="btn btn-accent">
+            Explore Proof Records
           </a>
           <a href="{{ '/action' | url }}" class="btn btn-outline-white">
             Take Action
@@ -78,7 +78,7 @@ reviewDate: 2024-12-01
     </script>
 
     <div style="margin-top:40px">
-      <a href="{{ '/archive' | url }}" class="btn btn-outline-blue">View Full Proof Archive</a>
+      <a href="{{ '/case-studies/' | url }}" class="btn btn-outline-blue">View Case Studies</a>
     </div>
 
     <noscript><p>Enable JavaScript to load proof items.</p></noscript>

--- a/overproof.njk
+++ b/overproof.njk
@@ -19,7 +19,7 @@ eleventyComputed:
     <nav aria-label="Breadcrumb" class="breadcrumb">
       <ol>
         <li><a href="{{ '/' | url }}">Home</a></li>
-        <li><a href="{{ '/archive' | url }}">Proof</a></li>
+        <li><a href="{{ '/case-studies/' | url }}">Proof Record</a></li>
         <li aria-current="page">{{ overproofGroup.overproof.title }}</li>
       </ol>
     </nav>
@@ -38,8 +38,8 @@ eleventyComputed:
           {
             "@type": "ListItem",
             "position": 2,
-            "name": "Proof",
-            "item": "{{ site.url }}{{ '/archive/' | url }}"
+            "name": "Proof Record",
+            "item": "{{ site.url }}{{ '/case-studies/' | url }}"
           },
           {
             "@type": "ListItem",


### PR DESCRIPTION
## Summary
- point the primary "Proof" navigation item toward the case studies index so readers start with overproof narratives
- ensure proof and overproof breadcrumbs reference the case studies hub as the archive entry point
- retune homepage calls to action and mobile footer highlighting to emphasize case studies while keeping the full archive accessible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d435f2814c8330857029964127f42e