### PR TITLE
Fix case studies listing

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -698,8 +698,24 @@ module.exports = function(eleventyConfig) {
       });
   });
 
-  eleventyConfig.addCollection("caseStudies", function(collectionApi) {
-    return createIntentCollection(collectionApi, "case-study");
+  eleventyConfig.addCollection("caseStudies", function() {
+    const { overproofGroups } = getProofCollections();
+
+    return overproofGroups.map((group) => {
+      const overproof = group?.overproof ?? {};
+      const slug = overproof.slug ? slugifyValue(overproof.slug) : slugifyValue(overproof.title ?? overproof.id ?? "");
+      const url = slug ? `/proofs/${slug}/` : null;
+
+      return {
+        url,
+        data: {
+          overproofGroup: group,
+          tasks: ["proof-record", "precedent"],
+          intentOrder: Number.isFinite(overproof.order) ? overproof.order : Number.POSITIVE_INFINITY,
+          title: overproof.title ?? overproof.short_title ?? slug
+        }
+      };
+    });
   });
 
   eleventyConfig.addFilter("date", (dateObj, format = "LLLL d, yyyy") => {


### PR DESCRIPTION
## Summary
- rebuild the `caseStudies` collection from the overproof groups so every proof record is exposed to the template
- derive each entry’s URL, title metadata, and default tasks when shaping the collection items

## Testing
- npx @11ty/eleventy --quiet

------
https://chatgpt.com/codex/tasks/task_e_68d4382a31dc83308aadc1e62153cbbf