### PR TITLE
Revamp case studies layout and dark navigation

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -70,7 +70,7 @@
 <body>
 
   {% set currentUrl = page.url or '/' %}
-  {% set proofActive = currentUrl == '/case-studies/' or currentUrl == '/case-studies/index.html' or currentUrl.startsWith('/proofs/') %}
+  {% set proofActive = currentUrl == '/archive/' or currentUrl == '/archive/index.html' or currentUrl.startsWith('/proofs/') %}
   {% set actionActive = currentUrl == '/action/' or currentUrl == '/action/index.html' or currentUrl.startsWith('/action/') %}
   {% set caseStudiesActive = currentUrl == '/case-studies/' or currentUrl == '/case-studies/index.html' %}
   {% set aboutActive = currentUrl == '/about/' or currentUrl == '/about/index.html' %}
@@ -99,7 +99,7 @@
           </svg>
         </button>
         <ul class="nav-links" id="primary-nav">
-          <li><a href="{{ '/case-studies/' | url }}"{% if proofActive %} class="is-active" aria-current="page"{% endif %}>Proof</a></li>
+          <li><a href="{{ '/archive/' | url }}"{% if proofActive %} class="is-active" aria-current="page"{% endif %}>Proof</a></li>
           <li class="nav-item-search"><a href="{{ '/archive/#search-input' | url }}" data-search-link aria-label="Search proofs">Search</a></li>
           <li><a href="{{ '/case-studies/' | url }}"{% if caseStudiesActive %} class="is-active" aria-current="page"{% endif %}>Case Studies</a></li>
           <li><a href="{{ '/action/' | url }}"{% if actionActive %} class="is-active" aria-current="page"{% endif %}>Filing Guide</a></li>

--- a/case-studies.njk
+++ b/case-studies.njk
@@ -14,28 +14,68 @@ reviewDate: 2024-12-01
 
     {% set studies = collections.caseStudies %}
     {% if studies and studies | length %}
-    <div class="resource-list" role="list">
+    <div class="case-study-list" role="list">
       {% for study in studies %}
       {% set overproofGroup = study.data.overproofGroup %}
       {% set overproof = overproofGroup.overproof %}
       {% set studyTitle = (overproof.brief and overproof.brief.headline) or overproof.short_title or overproof.title %}
       {% set studySummary = study.data.description or (overproof.brief and overproof.brief.lede) or overproof.summary %}
       {% set proofCount = overproof.proofCount or (overproofGroup.proofs | length) %}
-      <article class="resource-card" role="listitem">
-        <h2><a href="{{ study.url | url }}">{{ studyTitle }}</a></h2>
-        {% if studySummary %}
-        <p>{{ studySummary }}</p>
-        {% endif %}
-        {% if proofCount %}
-        <p class="resource-card__meta">{{ proofCount }} proof{% if proofCount != 1 %}s{% endif %} documented</p>
-        {% endif %}
-        {% if study.data.tasks and study.data.tasks | length %}
-        <ul class="resource-card__tasks">
-          {% for task in study.data.tasks %}
-          <li>{{ task | replace('-', ' ') | capitalize }}</li>
-          {% endfor %}
-        </ul>
-        {% endif %}
+      <article class="case-study-card" role="listitem">
+        <header class="case-study-card__header">
+          {% if overproof.umbrella_category %}
+          <p class="case-study-card__kicker">{{ overproof.umbrella_category }}</p>
+          {% endif %}
+          <h2><a href="{{ study.url | url }}">{{ studyTitle }}</a></h2>
+          {% if studySummary %}
+          <p class="case-study-card__summary">{{ studySummary }}</p>
+          {% endif %}
+        </header>
+
+        <div class="case-study-card__content">
+          {% if overproof.key_points and overproof.key_points | length %}
+          <div class="case-study-card__facts">
+            <h3>Key Findings</h3>
+            <ul>
+              {% for point in overproof.key_points %}
+              <li>{{ point }}</li>
+              {% endfor %}
+            </ul>
+          </div>
+          {% endif %}
+
+          <div class="case-study-card__details">
+            <h3>At a Glance</h3>
+            <dl>
+              {% if proofCount %}
+              <div>
+                <dt>Proofs documented</dt>
+                <dd>{{ proofCount }}</dd>
+              </div>
+              {% endif %}
+              {% if overproof.metadata %}
+                {% for label, value in overproof.metadata %}
+                <div>
+                  <dt>{{ label }}</dt>
+                  <dd>{{ value }}</dd>
+                </div>
+                {% endfor %}
+              {% endif %}
+            </dl>
+
+            {% if study.data.tasks and study.data.tasks | length %}
+            <ul class="case-study-card__tags" aria-label="Available resources">
+              {% for task in study.data.tasks %}
+              <li>{{ task | replace('-', ' ') | capitalize }}</li>
+              {% endfor %}
+            </ul>
+            {% endif %}
+          </div>
+        </div>
+
+        <footer class="case-study-card__footer">
+          <a class="case-study-card__cta" href="{{ study.url | url }}">View full case study</a>
+        </footer>
       </article>
       {% endfor %}
     </div>

--- a/style.css
+++ b/style.css
@@ -330,10 +330,29 @@
 
 [data-theme="dark"] .nav{
   background:var(--color-surface-muted);
-  color:var(--color-interactive-primary);
-  --nav-active-bg: rgba(37,99,235,0.32);
-  --nav-active-text: var(--color-primary-200);
-  --nav-active-border: var(--color-primary-200);
+  color:var(--color-text-base);
+  --nav-active-bg: rgba(255,255,255,0.08);
+  --nav-active-text: var(--color-text-base);
+  --nav-active-border: rgba(255,255,255,0.4);
+  --nav-toggle-color: var(--color-text-base);
+}
+
+[data-theme="dark"] .nav-links a{
+  color:var(--color-text-base);
+}
+
+[data-theme="dark"] .nav-links a:hover,
+[data-theme="dark"] .nav-links a:focus-visible,
+[data-theme="dark"] .nav-links a:active{
+  color:var(--color-text-base);
+  border-bottom-color:rgba(255,255,255,0.6);
+}
+
+[data-theme="dark"] .nav-links a[data-search-link]:hover,
+[data-theme="dark"] .nav-links a[data-search-link]:focus-visible,
+[data-theme="dark"] .nav-links a[data-search-link]:active{
+  background:rgba(255,255,255,0.08);
+  color:var(--color-text-base);
 }
 
 [data-theme="dark"] .wordmark{content:url('/images/wordmark-white-on-blue.svg')}
@@ -1474,59 +1493,187 @@ p{
 /* Section wrapper padding (all breakpoints) */
 .content-page { padding: calc(var(--space-8) + var(--space-6)) 0; }
 
-.resource-list {
-  display: grid;
-  gap: var(--space-5);
+.case-study-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
   margin-top: var(--space-6);
 }
 
-@media (min-width:768px) {
-  .resource-list {
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  }
+.case-study-card {
+  background: var(--paper-light);
+  border: 1px solid var(--border-soft);
+  border-radius: 16px;
+  padding: clamp(var(--space-5), 2vw, var(--space-6));
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
 }
 
-.resource-card {
-  background: var(--paper-light);
-  border-radius: 12px;
-  padding: var(--space-5);
-  box-shadow: var(--shadow-sm);
+.case-study-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.case-study-card__kicker {
+  font-size: var(--font-size-xs);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.case-study-card__summary {
+  font-size: clamp(var(--font-size-base), 1.12rem, var(--font-size-lg));
+  color: var(--text);
+}
+
+.case-study-card__content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.case-study-card__facts,
+.case-study-card__details {
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
 }
 
-.resource-card h2 {
-  margin: 0;
-}
-
-.resource-card p {
-  margin: 0;
-}
-
-.resource-card__meta {
+.case-study-card__facts h3,
+.case-study-card__details h3 {
   font-size: var(--font-size-sm);
-  color: var(--muted);
+  letter-spacing: .5px;
+  text-transform: uppercase;
+  color: var(--text-muted);
 }
 
-.resource-card__tasks {
-  list-style: none;
+.case-study-card__facts ul {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+.case-study-card__facts li {
+  font-size: var(--font-size-base);
+  line-height: 1.5;
+}
+
+.case-study-card__details dl {
+  display: grid;
+  gap: var(--space-3);
+  margin: 0;
+}
+
+.case-study-card__details dl > div {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.case-study-card__details dt {
+  font-size: var(--font-size-xs);
+  letter-spacing: .5px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.case-study-card__details dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.case-study-card__tags {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-2);
+  list-style: none;
   margin: 0;
   padding: 0;
 }
 
-.resource-card__tasks li {
-  background: var(--color-interactive-neutral);
-  color: var(--color-text-base);
+.case-study-card__tags li {
+  background: var(--color-surface-muted);
+  color: var(--text);
   border-radius: 999px;
-  padding: 0.35rem 0.85rem;
+  padding: var(--space-1) var(--space-3);
   font-size: var(--font-size-xs);
-  letter-spacing: 0.08em;
+  letter-spacing: .5px;
   text-transform: uppercase;
+}
+
+.case-study-card__footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.case-study-card__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
   font-weight: 700;
+  color: var(--color-link-default);
+}
+
+.case-study-card__cta::after {
+  content: "→";
+  font-size: 1rem;
+}
+
+.case-study-card__cta:hover,
+.case-study-card__cta:focus-visible {
+  color: var(--color-link-hover);
+  text-decoration: underline;
+}
+
+@media (min-width: 960px) {
+  .case-study-card__content {
+    flex-direction: row;
+    align-items: stretch;
+  }
+
+  .case-study-card__facts {
+    flex: 2 1 0;
+    padding-right: var(--space-5);
+    border-right: 1px solid var(--border-soft);
+  }
+
+  .case-study-card__details {
+    flex: 1 1 0;
+    padding-left: var(--space-5);
+  }
+
+  .case-study-card__details dl {
+    gap: var(--space-4);
+  }
+}
+
+[data-theme="dark"] .case-study-card {
+  background: var(--paper-light);
+  border-color: var(--color-border-subtle);
+  box-shadow: none;
+}
+
+[data-theme="dark"] .case-study-card__facts {
+  border-color: var(--color-border-subtle);
+}
+
+[data-theme="dark"] .case-study-card__tags li {
+  background: rgba(255,255,255,0.1);
+  color: var(--color-text-base);
+}
+
+[data-theme="dark"] .case-study-card__cta {
+  color: var(--color-text-base);
+}
+
+[data-theme="dark"] .case-study-card__cta:hover,
+[data-theme="dark"] .case-study-card__cta:focus-visible {
+  color: var(--color-white);
 }
 
 /* Overproof record */

--- a/tests/dark-mode.spec.js
+++ b/tests/dark-mode.spec.js
@@ -3,8 +3,8 @@ import { test, expect } from '@playwright/test';
 const DARK_BODY_BG = 'rgb(15, 23, 42)';
 const DARK_TEXT = 'rgb(241, 245, 249)';
 const DARK_SURFACE = 'rgb(30, 41, 59)';
-const DARK_NAV_TEXT = 'rgb(37, 99, 235)';
-const DARK_LINK = 'rgb(147, 197, 253)';
+const DARK_NAV_TEXT = 'rgb(241, 245, 249)';
+const DARK_LINK = 'rgb(241, 245, 249)';
 
 test.describe('dark theme styling', () => {
   test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
## Summary
- redirect the top-level Proof nav item to the archive so it no longer duplicates the Case Studies link
- redesign the case studies listing into single-column horizontal cards with key findings, metadata, and clearer call-to-action
- refresh dark theme styles to use high-contrast white navigation text and support the new case study layout, updating the dark mode test expectations accordingly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5676d6950833086fff2eaa4eaaabd