### PR TITLE
Improve action guide layout and footer organization

### DIFF
--- a/_includes/layout.njk
+++ b/_includes/layout.njk
@@ -132,22 +132,41 @@
           <p><strong>Proof. Not Spin.</strong></p>
           <p>A 100% volunteer-run project. We do not solicit or accept financial contributions. We do not endorse candidates.</p>
           <p><a href="mailto:setho@democraticjustice.org">Submit Proof Confidentially</a></p>
-          <p><a href="{{ '/integrity' | url }}">Proof of Integrity</a></p>
-          <p><a href="{{ '/privacy' | url }}">Privacy Policy</a></p>
           <p>&copy; {{ now | date('%Y') }} Democratic Justice. All rights reserved.</p>
         </div>
         <nav class="footer-nav" aria-label="Footer navigation">
-          <ul class="footer-nav__list">
-            <li><a href="{{ '/' | url }}">Home</a></li>
-            <li><a href="{{ '/archive/' | url }}">Proof Archive</a></li>
-            <li><a href="{{ '/archive/#search-input' | url }}" data-search-link>Search Proofs</a></li>
-            <li><a href="{{ '/overproofs/' | url }}">Overproofs</a></li>
-            <li><a href="{{ '/method/' | url }}">Method</a></li>
-            <li><a href="{{ '/action/' | url }}">Action</a></li>
-            <li><a href="{{ '/about/' | url }}">About Us</a></li>
-            <li><a href="{{ '/contact/' | url }}">Contact</a></li>
-            <li><a href="{{ '/submit/' | url }}">Submit Proof</a></li>
-          </ul>
+          <div class="footer-nav__group">
+            <h3 class="footer-nav__heading">About</h3>
+            <ul class="footer-nav__list">
+              <li><a href="{{ '/about/' | url }}">About Us</a></li>
+              <li><a href="{{ '/method/' | url }}">Method</a></li>
+              <li><a href="{{ '/integrity' | url }}">Proof of Integrity</a></li>
+              <li><a href="{{ '/contact/' | url }}">Contact</a></li>
+            </ul>
+          </div>
+          <div class="footer-nav__group">
+            <h3 class="footer-nav__heading">Resources</h3>
+            <ul class="footer-nav__list">
+              <li><a href="{{ '/' | url }}">Home</a></li>
+              <li><a href="{{ '/archive/' | url }}">Proof Archive</a></li>
+              <li><a href="{{ '/archive/#search-input' | url }}" data-search-link>Search Proofs</a></li>
+              <li><a href="{{ '/overproofs/' | url }}">Overproofs</a></li>
+              <li><a href="{{ '/action/' | url }}">Action Guide</a></li>
+            </ul>
+          </div>
+          <div class="footer-nav__group">
+            <h3 class="footer-nav__heading">Get Involved</h3>
+            <ul class="footer-nav__list">
+              <li><a href="{{ '/submit/' | url }}">Submit Proof</a></li>
+              <li><a href="{{ '/action/file' | url }}">Request a Review</a></li>
+            </ul>
+          </div>
+          <div class="footer-nav__group">
+            <h3 class="footer-nav__heading">Legal</h3>
+            <ul class="footer-nav__list">
+              <li><a href="{{ '/privacy' | url }}">Privacy Policy</a></li>
+            </ul>
+          </div>
         </nav>
       </div>
       <a href="{{ '/' | url }}" aria-label="Democratic Justice home">

--- a/action/index.njk
+++ b/action/index.njk
@@ -20,9 +20,9 @@ reviewDate: 2024-12-01
       <p><strong>Follow the process in order.</strong> Procedural errors can lead to dismissal. This guide walks you through the correct steps, starting with seeking a remedy within the state party.</p>
     </div>
     
-    <div class="pre-check-box">
-      <h2>Do You Have a Case? Quick Checklist</h2>
-      <p>Before you file, make sure you can answer YES to all of these questions:</p>
+    <div class="pre-check-box" role="region" aria-labelledby="pre-check-heading">
+      <h2 id="pre-check-heading">Quick Checklist: Confirm Your Case</h2>
+      <p>Run through each point before you start filing. You should be able to answer <strong>yes</strong> to all of them:</p>
       <ul>
         <li>
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z" clip-rule="evenodd" /></svg>
@@ -41,100 +41,108 @@ reviewDate: 2024-12-01
           <span>Are you within the <strong>30-day filing deadline</strong> from the date of the decision or event?</span>
         </li>
       </ul>
-      <p class="checklist-footer">If you answered yes to all of the above, proceed to Step 1 below.</p>
+      <p class="checklist-footer">If you answered yes to all of the above, jump into Step 1 below.</p>
     </div>
 
-    <div class="action-step">
-      <h2 class="step-title"><span class="step-number">1</span>Start in West Virginia</h2>
-      <p class="step-description">You must exhaust all state-level remedies before escalating. Start with one of the actions below.</p>
-    </div>
-    
-    <div class="action-card-grid">
-      <div class="action-card">
-        <div class="action-card-icon">
-          {% image "/images/three-dots-blue.svg", "Icon symbolizing appealing a decision for West Virginia Democrats", {
-            widths: [40, 80],
-            sizes: "40px"
-          } %}
-        </div>
-        <h3>Appeal a Decision</h3>
-        <p>Contest a formal decision made by a committee or an attendance-based removal.</p>
-        <button class="btn btn-accent" data-modal-target="modal-appeal-decision">View Steps</button>
+    <section class="action-section action-section--state" aria-labelledby="step-one-heading">
+      <div class="action-step">
+        <h2 class="step-title" id="step-one-heading"><span class="step-number">1</span><span class="step-title__label">Start in West Virginia</span></h2>
+        <p class="step-description">You must exhaust all state-level remedies before escalating. Choose the action that matches your situation.</p>
       </div>
-      <div class="action-card">
-        <div class="action-card-icon">
-          {% image "/images/three-dots-blue.svg", "Icon symbolizing contesting a delegation in West Virginia", {
-            widths: [40, 80],
-            sizes: "40px"
-          } %}
-        </div>
-        <h3>Contest a Delegation</h3>
-        <p>Challenge the outcome of a caucus or convention where delegates were selected.</p>
-        <button class="btn btn-accent" data-modal-target="modal-contest-delegation">View Steps</button>
-      </div>
-      <div class="action-card">
-       <div class="action-card-icon">
-         {% image "/images/three-dots-blue.svg", "Icon symbolizing removing a committee member in West Virginia", {
-           widths: [40, 80],
-           sizes: "40px"
-         } %}
-       </div>
-        <h3>Remove a Member</h3>
-        <p>Initiate the removal of a committee member for cause, such as rule violations.</p>
-        <button class="btn btn-accent" data-modal-target="modal-remove-member">View Steps</button>
-      </div>
-      <div class="action-card">
-        <div class="action-card-icon">
-          {% image "/images/three-dots-blue.svg", "Icon symbolizing removing an officer in West Virginia", {
-            widths: [40, 80],
-            sizes: "40px"
-          } %}
-        </div>
-        <h3>Remove an Officer</h3>
-        <p>Initiate the removal of an officer from their position for cause.</p>
-        <button class="btn btn-accent" data-modal-target="modal-remove-officer">View Steps</button>
-      </div>
-    </div> 
 
-    <hr class="section-divider">
-
-    <div class="action-step">
-      <h2 class="step-title"><span class="step-number">2</span>Escalate to the DNC</h2>
-      <p class="step-description">If state-level remedies fail or are unavailable, you may file with the DNC. Strict deadlines apply.</p>
-    </div>
-
-    <div class="action-card-grid">
-      <div class="action-card is-escalation">
-        <div class="action-card-icon">
-          {% image "/images/three-dots-white.svg", "Icon symbolizing a DNC credentials challenge for West Virginia Democrats", {
-            widths: [40, 80],
-            sizes: "40px"
-          } %}
-        </div>
-        <h3>File a DNC Credentials Challenge</h3>
-        <p>Challenge the selection of a DNC member from West Virginia.</p>
-        <button class="btn btn-navy" data-modal-target="modal-dnc-credentials">View Steps</button>
+      <div class="action-card-grid">
+        <article class="action-card">
+          <div class="action-card-content">
+            <div class="action-card-icon" aria-hidden="true">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3V20.25M12 20.25C10.528 20.25 9.1179 20.515 7.81483 21M12 20.25C13.472 20.25 14.8821 20.515 16.1852 21M18.75 4.97089C16.5446 4.66051 14.291 4.5 12 4.5C9.70897 4.5 7.45542 4.66051 5.25 4.97089M18.75 4.97089C19.7604 5.1131 20.7608 5.28677 21.75 5.49087M18.75 4.97089L21.3704 15.6961C21.4922 16.1948 21.2642 16.7237 20.7811 16.8975C20.1468 17.1257 19.4629 17.25 18.75 17.25C18.0371 17.25 17.3532 17.1257 16.7189 16.8975C16.2358 16.7237 16.0078 16.1948 16.1296 15.6961L18.75 4.97089ZM2.25 5.49087C3.23922 5.28677 4.23956 5.1131 5.25 4.97089M5.25 4.97089L7.87036 15.6961C7.9922 16.1948 7.76419 16.7237 7.28114 16.8975C6.6468 17.1257 5.96292 17.25 5.25 17.25C4.53708 17.25 3.8532 17.1257 3.21886 16.8975C2.73581 16.7237 2.5078 16.1948 2.62964 15.6961L5.25 4.97089Z" /></svg>
+            </div>
+            <div class="action-card-copy">
+              <h3>Appeal a Decision</h3>
+              <p>Contest a formal decision made by a committee or an attendance-based removal.</p>
+            </div>
+          </div>
+          <button class="btn btn-accent" data-modal-target="modal-appeal-decision">View Steps</button>
+        </article>
+        <article class="action-card">
+          <div class="action-card-content">
+            <div class="action-card-icon" aria-hidden="true">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M15 19.1276C15.8329 19.37 16.7138 19.5 17.625 19.5C19.1037 19.5 20.5025 19.1576 21.7464 18.5478C21.7488 18.4905 21.75 18.4329 21.75 18.375C21.75 16.0968 19.9031 14.25 17.625 14.25C16.2069 14.25 14.956 14.9655 14.2136 16.0552M15 19.1276V19.125C15 18.0121 14.7148 16.9658 14.2136 16.0552M15 19.1276C15 19.1632 14.9997 19.1988 14.9991 19.2343C13.1374 20.3552 10.9565 21 8.625 21C6.29353 21 4.11264 20.3552 2.25092 19.2343C2.25031 19.198 2.25 19.1615 2.25 19.125C2.25 15.6042 5.10418 12.75 8.625 12.75C11.0329 12.75 13.129 14.085 14.2136 16.0552M12 6.375C12 8.23896 10.489 9.75 8.625 9.75C6.76104 9.75 5.25 8.23896 5.25 6.375C5.25 4.51104 6.76104 3 8.625 3C10.489 3 12 4.51104 12 6.375ZM20.25 8.625C20.25 10.0747 19.0747 11.25 17.625 11.25C16.1753 11.25 15 10.0747 15 8.625C15 7.17525 16.1753 6 17.625 6C19.0747 6 20.25 7.17525 20.25 8.625Z" /></svg>
+            </div>
+            <div class="action-card-copy">
+              <h3>Contest a Delegation</h3>
+              <p>Challenge the outcome of a caucus or convention where delegates were selected.</p>
+            </div>
+          </div>
+          <button class="btn btn-accent" data-modal-target="modal-contest-delegation">View Steps</button>
+        </article>
+        <article class="action-card">
+          <div class="action-card-content">
+            <div class="action-card-icon" aria-hidden="true">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10.5H16M13.75 6.375C13.75 8.23896 12.239 9.75 10.375 9.75C8.51104 9.75 7 8.23896 7 6.375C7 4.51104 8.51104 3 10.375 3C12.239 3 13.75 4.51104 13.75 6.375ZM4.00092 19.2343C4.00031 19.198 4 19.1615 4 19.125C4 15.6042 6.85418 12.75 10.375 12.75C13.8958 12.75 16.75 15.6042 16.75 19.125V19.1276C16.75 19.1632 16.7497 19.1988 16.7491 19.2343C14.8874 20.3552 12.7065 21 10.375 21C8.04353 21 5.86264 20.3552 4.00092 19.2343Z" /></svg>
+            </div>
+            <div class="action-card-copy">
+              <h3>Remove a Member</h3>
+              <p>Initiate the removal of a committee member for cause, such as rule violations.</p>
+            </div>
+          </div>
+          <button class="btn btn-accent" data-modal-target="modal-remove-member">View Steps</button>
+        </article>
+        <article class="action-card">
+          <div class="action-card-content">
+            <div class="action-card-icon" aria-hidden="true">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 12.7498L11.25 14.9998L15 9.74985M12 2.71411C9.8495 4.75073 6.94563 5.99986 3.75 5.99986C3.69922 5.99986 3.64852 5.99955 3.59789 5.99892C3.2099 7.17903 3 8.43995 3 9.74991C3 15.3414 6.82432 20.0397 12 21.3719C17.1757 20.0397 21 15.3414 21 9.74991C21 8.43995 20.7901 7.17903 20.4021 5.99892C20.3515 5.99955 20.3008 5.99986 20.25 5.99986C17.0544 5.99986 14.1505 4.75073 12 2.71411Z" /></svg>
+            </div>
+            <div class="action-card-copy">
+              <h3>Remove an Officer</h3>
+              <p>Initiate the removal of an officer from their position for cause.</p>
+            </div>
+          </div>
+          <button class="btn btn-accent" data-modal-target="modal-remove-officer">View Steps</button>
+        </article>
       </div>
-      <div class="action-card is-escalation">
-       <div class="action-card-icon">
-         {% image "/images/three-dots-white.svg", "Icon symbolizing a DNC rules complaint for West Virginia Democrats", {
-           widths: [40, 80],
-           sizes: "40px"
-         } %}
-       </div>
-        <h3>File a DNC Rules Complaint</h3>
-        <p>File a complaint if state rules violate DNC charter provisions for participation.</p>
-        <button class="btn btn-navy" data-modal-target="modal-rbc-complaint">View Steps</button>
-      </div>
-    </div> 
+    </section>
 
-    <hr class="section-divider">
-    
-    <div class="cta-box">
-      <h2>Feeling stuck? We can help.</h2>
-      <p>Use the challenge review intake to share your draft. We'll double-check deadlines, formatting, and evidence to ensure your filing is solid.</p>
-      <a href="{{ '/action/file' | url }}" class="btn btn-accent" id="request-review-btn">Request a Review</a>
-    </div>
+    <section class="action-section action-section--dnc" aria-labelledby="step-two-heading">
+      <div class="action-step">
+        <h2 class="step-title" id="step-two-heading"><span class="step-number">2</span><span class="step-title__label">Escalate to the DNC</span></h2>
+        <p class="step-description">If state-level remedies fail or are unavailable, you may file with the DNC. Strict deadlines apply.</p>
+      </div>
+
+      <div class="action-card-grid">
+        <article class="action-card is-escalation">
+          <div class="action-card-content">
+            <div class="action-card-icon" aria-hidden="true">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3V4.5M3 21V15M3 15L5.77009 14.3075C7.85435 13.7864 10.0562 14.0281 11.9778 14.9889L12.0856 15.0428C13.9687 15.9844 16.1224 16.2359 18.1718 15.7537L21.2861 15.0209C21.097 13.2899 21 11.5313 21 9.75C21 7.98343 21.0954 6.23914 21.2814 4.52202L18.1718 5.25369C16.1224 5.73591 13.9687 5.48435 12.0856 4.54278L11.9778 4.48892C10.0562 3.52812 7.85435 3.28641 5.77009 3.80748L3 4.5M3 15V4.5" /></svg>
+            </div>
+            <div class="action-card-copy">
+              <h3>File a DNC Credentials Challenge</h3>
+              <p>Challenge the selection of a DNC member from West Virginia.</p>
+            </div>
+          </div>
+          <button class="btn btn-navy" data-modal-target="modal-dnc-credentials">View Steps</button>
+        </article>
+        <article class="action-card is-escalation">
+          <div class="action-card-content">
+            <div class="action-card-icon" aria-hidden="true">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M19.5 14.25V11.625C19.5 9.76104 17.989 8.25 16.125 8.25H14.625C14.0037 8.25 13.5 7.74632 13.5 7.125V5.625C13.5 3.76104 11.989 2.25 10.125 2.25H8.25M8.25 15H15.75M8.25 18H12M10.5 2.25H5.625C5.00368 2.25 4.5 2.75368 4.5 3.375V20.625C4.5 21.2463 5.00368 21.75 5.625 21.75H18.375C18.9963 21.75 19.5 21.2463 19.5 20.625V11.25C19.5 6.27944 15.4706 2.25 10.5 2.25Z" /></svg>
+            </div>
+            <div class="action-card-copy">
+              <h3>File a DNC Rules Complaint</h3>
+              <p>File a complaint if state rules violate DNC charter provisions for participation.</p>
+            </div>
+          </div>
+          <button class="btn btn-navy" data-modal-target="modal-rbc-complaint">View Steps</button>
+        </article>
+      </div>
+    </section>
+
+    <section class="action-section action-section--support">
+      <div class="cta-box">
+        <h2 id="request-review-heading">Feeling stuck? We can help.</h2>
+        <p>Use the challenge review intake to share your draft. We'll double-check deadlines, formatting, and evidence to ensure your filing is solid.</p>
+        <a href="{{ '/action/file' | url }}" class="btn btn-accent" id="request-review-btn" aria-labelledby="request-review-heading">Request a Review</a>
+      </div>
+    </section>
   </div> 
 
   <div id="modal-appeal-decision" class="modal" hidden><div class="modal-content"><button class="modal-close" aria-label="Close modal">&times;</button><div class="modal-header"><div class="modal-header-icon">{% image "/images/three-dots-white.svg", "Icon symbolizing appealing a decision for West Virginia Democrats", { widths: [40, 80], sizes: "40px" } %}</div><h3>Procedure: Appealing a Decision</h3></div><div class="modal-body"><p class="modal-summary">Use this process to formally challenge a ruling or decision made by a WV Democratic committee, club, or convention.</p><div class="key-facts-box"><h4>Key Facts</h4><ul><li><strong>Filing Deadline:</strong> 30 days from the date of the decision.</li><li><strong>Who Can File:</strong> The party that lost the decision.</li><li><strong>Source:</strong> WVSDEC Bylaws, Art. VIII, Sec. 2-3</li></ul></div><hr class="modal-divider"><h4>Your Step-by-Step Guide</h4><ol><li><strong>Draft Your Appeal:</strong> Prepare a formal written notice. Clearly state the decision you are contesting, the date it was made, and the specific reasons for your appeal.</li><li><strong>File with the State Chair:</strong> You must <strong>submit</strong> your written notice to the WVSDEC State Chair within the 30-day deadline.</li><li><strong>Await Hearing Notice:</strong> The Board of Appeals will be called for a hearing within 30 days. You will receive at least 5 days' written notice of the hearing.</li></ol><hr class="modal-divider"><h4>What to Expect Next</h4><p>You must attend the hearing to present your case. If you fail to appear without good cause, a decision will likely be made against you. The Board's decision is final unless overturned by a 2/3 vote of the full State Executive Committee.</p></div></div></div>

--- a/style.css
+++ b/style.css
@@ -1280,17 +1280,34 @@ p{
 .footer-mission p:last-of-type{
   margin-bottom:0;
 }
+.footer-nav {
+  display: grid;
+  gap: var(--space-5);
+}
+@media (min-width:640px){
+  .footer-nav {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
+}
+.footer-nav__group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.footer-nav__heading {
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-primary-200);
+  margin: 0;
+}
 .footer-nav__list{
   list-style:none;
   margin:0;
   padding:0;
-  display:grid;
-  gap: var(--space-3);
-}
-@media (min-width:640px){
-  .footer-nav__list{
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  }
+  display:flex;
+  flex-direction:column;
+  gap: var(--space-2);
 }
 .footer-nav__list li{
   margin:0;
@@ -2226,23 +2243,26 @@ html { scroll-behavior: smooth; }
 
 /* Pre-Action Checklist Box (Dark Theme) */
 .pre-check-box {
-  background: var(--navy);
-  border: 1px solid var(--navy);
+  background: var(--color-surface-accent);
+  border: 1px solid var(--color-border-accent);
   border-left: 4px solid var(--brand);
-  border-radius: 8px;
-  padding: 1.5rem 2rem;
+  border-radius: 12px;
+  padding: 2rem clamp(1.5rem, 2vw, 2.5rem);
   margin: 2rem 0 3rem 0;
+  box-shadow: var(--shadow-sm);
 }
 .pre-check-box h2 {
-  color: var(--white);
+  color: var(--color-text-strong);
   margin-top: 0;
-  font-size: clamp(24px, 3vw, 28px);
+  font-size: clamp(1.75rem, 3vw, 2rem);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
 }
 .pre-check-box p {
-  color: var(--silver);
+  color: var(--color-text-muted);
   max-width: none;
   margin-bottom: 1.5rem;
-  font-size: 1.1rem;
+  font-size: 1.05rem;
 }
 .pre-check-box ul {
   list-style: none;
@@ -2253,10 +2273,10 @@ html { scroll-behavior: smooth; }
   display: flex;
   align-items: flex-start;
   gap: 0.75rem;
-  font-size: 1.1rem;
+  font-size: 1.05rem;
   margin-bottom: 1rem;
   line-height: 1.5;
-  color: var(--paper);
+  color: var(--color-text-base);
 }
 .pre-check-box li svg {
   flex-shrink: 0;
@@ -2268,51 +2288,80 @@ html { scroll-behavior: smooth; }
 .pre-check-box .checklist-footer {
   font-weight: 700;
   margin-bottom: 0;
-  color: var(--brand);
+  color: var(--brand-deep);
 }
 
 [data-theme="dark"] .pre-check-box {
   background: var(--surface-soft);
   border-color: var(--surface-soft);
   border-left-color: var(--brand);
+  box-shadow: none;
+}
+[data-theme="dark"] .pre-check-box h2 {
+  color: var(--paper);
 }
 [data-theme="dark"] .pre-check-box p,
 [data-theme="dark"] .pre-check-box li {
-  color: var(--text);
+  color: var(--paper);
 }
 
 /* Step-by-Step Section Styling */
+.action-section {
+  border-radius: 20px;
+  border: 1px solid var(--color-border-soft);
+  background: var(--color-surface-raised);
+  padding: clamp(2rem, 3vw, 3rem);
+  margin-bottom: clamp(2.5rem, 5vw, 4rem);
+  box-shadow: var(--shadow-sm);
+}
+.action-section--dnc {
+  background: var(--color-surface-subtle);
+}
+.action-section--support {
+  background: var(--color-surface-accent);
+  border-color: var(--color-border-accent);
+  box-shadow: var(--shadow-sm);
+}
 .action-step {
-  text-align: center;
+  text-align: left;
   margin-bottom: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 720px;
 }
 .step-title {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: 0.75rem;
-  margin-bottom: 0.5rem;
+  justify-content: flex-start;
+  gap: 1rem;
+  margin: 0;
+  font-size: clamp(1.9rem, 3vw, 2.4rem);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--navy);
+}
+.step-title__label {
+  line-height: 1.2;
 }
 .step-number {
-  background-color: var(--navy);
+  background-color: var(--brand);
   color: var(--white);
   border-radius: 50%;
-  width: 36px;
-  height: 36px;
+  width: 44px;
+  height: 44px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.2rem;
-  font-family: 'Oswald', Impact, sans-serif;
+  font-size: 1.25rem;
+  font-family: "Oswald", Impact, sans-serif;
   font-weight: 700;
-}
-.action-step:nth-of-type(2) .step-number {
-    background-color: var(--navy);
+  letter-spacing: normal;
 }
 .step-description {
-  max-width: 600px;
-  margin: 0 auto;
-  color: var(--muted);
+  max-width: 60ch;
+  margin: 0;
+  color: var(--color-text-muted);
   font-size: 1.1rem;
 }
 .section-divider {
@@ -2325,59 +2374,120 @@ html { scroll-behavior: smooth; }
 /* Action Card Grid & Card Styling */
 .action-card-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(1.5rem, 3vw, 2rem);
 }
 .action-card {
-  border-radius: 12px;
-  padding: 1.5rem;
-  background-color: var(--paper-light);
+  border-radius: 16px;
+  padding: clamp(1.5rem, 2vw, 1.875rem);
+  background-color: var(--color-surface-raised);
+  border: 1px solid var(--color-border-soft);
   box-shadow: var(--shadow-sm);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
   display: flex;
   flex-direction: column;
+  gap: 1.5rem;
   text-align: left;
+  height: 100%;
 }
 .action-card:hover {
   transform: translateY(-4px);
   box-shadow: var(--shadow-md);
+  border-color: color-mix(in srgb, var(--brand) 30%, transparent);
 }
 .action-card:focus-within {
   box-shadow: var(--shadow-md);
+  border-color: color-mix(in srgb, var(--brand) 40%, transparent);
+}
+.action-card-content {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
 }
 .action-card-icon {
-  width: 40px;
-  height: 40px;
-  margin-bottom: 1rem;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 999px;
+  background: var(--color-surface-accent);
+  color: var(--brand);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--brand) 12%, transparent);
 }
-.action-card-icon img {
-  width: 100%;
-  height: 100%;
+.action-card-icon svg {
+  width: 1.75rem;
+  height: 1.75rem;
+  stroke: currentColor;
+}
+.action-card-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 .action-card h3 {
-  color: var(--text);
-  margin-bottom: 0.5rem;
+  color: var(--color-text-strong);
+  margin: 0;
+  font-size: 1.2rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 .action-card p {
-  flex-grow: 1;
-  color: var(--muted);
-  margin-bottom: 1.5rem;
+  color: var(--color-text-muted);
+  margin: 0;
   max-width: none;
+  font-size: 1.02rem;
 }
 .action-card .btn {
   align-self: flex-start;
+  margin-top: auto;
 }
 .action-card.is-escalation {
   background-color: var(--navy);
+  border-color: transparent;
 }
 .action-card.is-escalation h3,
 .action-card.is-escalation p {
   color: var(--white);
 }
+.action-card.is-escalation .action-card-icon {
+  background: rgba(255, 255, 255, 0.12);
+  box-shadow: none;
+  color: var(--white);
+}
+.action-card.is-escalation .action-card-content {
+  align-items: flex-start;
+}
 .btn-navy {
   background: var(--color-interactive-primary);
   color: var(--color-text-on-primary);
   border-color: var(--color-interactive-primary-border);
+}
+.cta-box {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  text-align: left;
+}
+.cta-box h2 {
+  margin: 0;
+  font-size: clamp(1.85rem, 3vw, 2.2rem);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--navy);
+}
+.cta-box p {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--color-text-base);
+  max-width: 60ch;
+}
+.action-section--support .cta-box h2 {
+  color: var(--color-text-strong);
+}
+.action-section--support .cta-box p {
+  color: var(--color-text-muted);
 }
 .btn-navy:hover {
   background: var(--color-interactive-primary-hover);


### PR DESCRIPTION
## Summary
- refresh the filing guide checklist and step sections with stronger alignment, new section wrappers, and updated icons for each action card
- enhance contrast and hierarchy for headings, cards, and the support call-to-action to make dense guidance easier to scan
- reorganize the footer into labeled link groups and add matching styles for clearer navigation

## Testing
- `npm run test` *(fails: Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5926e857c83309afea21edeb821c0