### PR TITLE
Adjust consequence styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -2174,6 +2174,11 @@ p{
   flex-wrap:wrap;
   gap:var(--space-2);
   margin:0;
+  padding:var(--space-3);
+  border:1px solid var(--color-border-soft);
+  border-radius:12px;
+  background:var(--color-surface-muted);
+  color:var(--color-text-base);
 }
 
 .violation-card__consequence span{


### PR DESCRIPTION
## Summary
- restyle the violation consequence callout to use neutral surface colors
- switch the consequence badge to a rectangular panel consistent with other UI elements

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5aed725cc83308ebad25cd93b9a6b