### PR TITLE
Restore latest proof feature and surface case file archive

### DIFF
--- a/_includes/case-study-list.njk
+++ b/_includes/case-study-list.njk
@@ -1,0 +1,70 @@
+{% set caseStudies = studies or [] %}
+{% if caseStudies and caseStudies | length %}
+<div class="case-study-list" role="list">
+  {% for study in caseStudies %}
+    {% set overproofGroup = study.data.overproofGroup %}
+    {% set overproof = overproofGroup.overproof %}
+    {% set studyTitle = (overproof.brief and overproof.brief.headline) or overproof.short_title or overproof.title %}
+    {% set studySummary = study.data.description or (overproof.brief and overproof.brief.lede) or overproof.summary %}
+    {% set proofCount = overproof.proofCount or (overproofGroup.proofs | length) %}
+    <article class="case-study-card" role="listitem">
+      <header class="case-study-card__header">
+        {% if overproof.umbrella_category %}
+        <p class="case-study-card__kicker">{{ overproof.umbrella_category }}</p>
+        {% endif %}
+        <h2><a href="{{ study.url | url }}">{{ studyTitle }}</a></h2>
+        {% if studySummary %}
+        <p class="case-study-card__summary">{{ studySummary }}</p>
+        {% endif %}
+      </header>
+
+      <div class="case-study-card__content">
+        {% if overproof.key_points and overproof.key_points | length %}
+        <div class="case-study-card__facts">
+          <h3>Key Findings</h3>
+          <ul>
+            {% for point in overproof.key_points %}
+            <li>{{ point }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+        {% endif %}
+
+        <div class="case-study-card__details">
+          <h3>At a Glance</h3>
+          <dl>
+            {% if proofCount %}
+            <div>
+              <dt>Proofs documented</dt>
+              <dd>{{ proofCount }}</dd>
+            </div>
+            {% endif %}
+            {% if overproof.metadata %}
+              {% for label, value in overproof.metadata %}
+              <div>
+                <dt>{{ label }}</dt>
+                <dd>{{ value }}</dd>
+              </div>
+              {% endfor %}
+            {% endif %}
+          </dl>
+
+          {% if study.data.tasks and study.data.tasks | length %}
+          <ul class="case-study-card__tags" aria-label="Available resources">
+            {% for task in study.data.tasks %}
+            <li>{{ task | replace('-', ' ') | capitalize }}</li>
+            {% endfor %}
+          </ul>
+          {% endif %}
+        </div>
+      </div>
+
+      <footer class="case-study-card__footer">
+        <a class="case-study-card__cta" href="{{ study.url | url }}">Read case brief</a>
+      </footer>
+    </article>
+  {% endfor %}
+</div>
+{% else %}
+<p>No case files are available yet. Check back soon.</p>
+{% endif %}

--- a/archive.njk
+++ b/archive.njk
@@ -27,14 +27,33 @@ reviewDate: 2024-12-01
     
     <div class="case-grid" id="case-grid" aria-live="polite">
       {%- for proof in collections.sortedProofs -%}
+      {% set overproof = proof.overproof or {} %}
+      {% set proofSlug = (proof.slug or proof.case_id) | slug %}
+      {% set overproofSlug = overproof.slug %}
+      {% set proofUrlPath = overproofSlug ? '/proofs/' ~ overproofSlug ~ '/' ~ proofSlug ~ '/' : null %}
+      {% set caseBriefTitle = overproof.short_title or overproof.title %}
+      {% set caseBriefPath = overproof.url or (overproofSlug ? '/briefs/' ~ overproofSlug ~ '/' : null) %}
       <article class="case-card" data-proof-id="{{ proof.case_id }}">
-        <h3><a href="{{ '/proofs/' | url }}{{ proof.overproof.slug }}/{{ proof.slug }}/">{{ proof.title }}</a></h3>
-        <p class="case-meta">
-          {{ proof.case_id }} • {{ proof.date | date }}
-          {%- if proof.category %} • <span style="font-weight: 700;">{{ proof.category }}</span>{% endif -%}
-        </p>
-        <p>{{ proof.thesis }}</p>
-        <a href="{{ '/proofs/' | url }}{{ proof.overproof.slug }}/{{ proof.slug }}/" class="case-link">Examine Proof →</a>
+        <div class="case-card__header">
+          {% if proofUrlPath %}
+          <h3 class="case-card__title"><a href="{{ proofUrlPath | url }}">{{ proof.title }}</a></h3>
+          {% else %}
+          <h3 class="case-card__title">{{ proof.title }}</h3>
+          {% endif %}
+          <p class="case-meta case-card__meta">
+            {{ proof.case_id }} • {{ proof.date | date }}
+            {%- if proof.category %} • <span style="font-weight: 700;">{{ proof.category }}</span>{% endif -%}
+          </p>
+        </div>
+        <p class="case-card__summary">{{ proof.thesis }}</p>
+        <div class="case-card__footer">
+          {% if proofUrlPath %}
+          <a href="{{ proofUrlPath | url }}" class="case-link">Examine Proof →</a>
+          {% endif %}
+          {% if caseBriefPath %}
+          <a href="{{ caseBriefPath | url }}" class="case-link case-link--subtle">View Case Brief: {{ caseBriefTitle }}</a>
+          {% endif %}
+        </div>
       </article>
       {%- endfor -%}
     </div>

--- a/case-studies.njk
+++ b/case-studies.njk
@@ -14,71 +14,7 @@ reviewDate: 2024-12-01
 
     {% set studies = collections.caseStudies %}
     {% if studies and studies | length %}
-    <div class="case-study-list" role="list">
-      {% for study in studies %}
-      {% set overproofGroup = study.data.overproofGroup %}
-      {% set overproof = overproofGroup.overproof %}
-      {% set studyTitle = (overproof.brief and overproof.brief.headline) or overproof.short_title or overproof.title %}
-      {% set studySummary = study.data.description or (overproof.brief and overproof.brief.lede) or overproof.summary %}
-      {% set proofCount = overproof.proofCount or (overproofGroup.proofs | length) %}
-      <article class="case-study-card" role="listitem">
-        <header class="case-study-card__header">
-          {% if overproof.umbrella_category %}
-          <p class="case-study-card__kicker">{{ overproof.umbrella_category }}</p>
-          {% endif %}
-          <h2><a href="{{ study.url | url }}">{{ studyTitle }}</a></h2>
-          {% if studySummary %}
-          <p class="case-study-card__summary">{{ studySummary }}</p>
-          {% endif %}
-        </header>
-
-      <div class="case-study-card__content">
-          {% if overproof.key_points and overproof.key_points | length %}
-          <div class="case-study-card__facts">
-            <h3>Key Findings</h3>
-            <ul>
-              {% for point in overproof.key_points %}
-              <li>{{ point }}</li>
-              {% endfor %}
-            </ul>
-          </div>
-          {% endif %}
-
-          <div class="case-study-card__details">
-            <h3>At a Glance</h3>
-            <dl>
-              {% if proofCount %}
-              <div>
-                <dt>Proofs documented</dt>
-                <dd>{{ proofCount }}</dd>
-              </div>
-              {% endif %}
-              {% if overproof.metadata %}
-                {% for label, value in overproof.metadata %}
-                <div>
-                  <dt>{{ label }}</dt>
-                  <dd>{{ value }}</dd>
-                </div>
-                {% endfor %}
-              {% endif %}
-            </dl>
-
-            {% if study.data.tasks and study.data.tasks | length %}
-            <ul class="case-study-card__tags" aria-label="Available resources">
-              {% for task in study.data.tasks %}
-              <li>{{ task | replace('-', ' ') | capitalize }}</li>
-              {% endfor %}
-            </ul>
-            {% endif %}
-          </div>
-        </div>
-
-        <footer class="case-study-card__footer">
-          <a class="case-study-card__cta" href="{{ study.url | url }}">Read case brief</a>
-        </footer>
-      </article>
-      {% endfor %}
-    </div>
+      {% include "case-study-list.njk" with { studies: studies } %}
     {% else %}
     <p>No overproofs are published yet. Check back soon.</p>
     {% endif %}

--- a/case.njk
+++ b/case.njk
@@ -133,6 +133,17 @@ eleventyComputed:
         </div>
       </div>
 
+      {% if overproof %}
+      {% set relatedProofCount = overproof.proofCount %}
+      <aside class="proof-related-case" aria-labelledby="proof-related-case-heading">
+        <div class="proof-related-case__text">
+          <h2 id="proof-related-case-heading">See the full case file</h2>
+          <p>Explore the {{ overproofLabel }} brief{% if relatedProofCount %} with {{ relatedProofCount }} documented proofs{% endif %} to understand how this record comes together.</p>
+        </div>
+        <a href="{{ overproofUrl }}" class="btn btn-outline-blue">View Case Brief</a>
+      </aside>
+      {% endif %}
+
     </header>
 
     <div class="doc-body">

--- a/index.njk
+++ b/index.njk
@@ -27,6 +27,63 @@ reviewDate: 2024-12-01
   </div>
 </header>
 
+{% set latestProof = collections.sortedProofs | last %}
+{% if latestProof and latestProof.overproof %}
+  {% set latestOverproof = latestProof.overproof %}
+  {% set latestProofSlug = (latestProof.slug or latestProof.case_id) | slug %}
+  {% set latestProofUrl = ('/proofs/' ~ latestOverproof.slug ~ '/' ~ latestProofSlug ~ '/') | url %}
+  {% set latestCaseUrl = (latestOverproof.url or ('/briefs/' ~ latestOverproof.slug ~ '/')) | url %}
+  {% set latestCaseTitle = latestOverproof.short_title or latestOverproof.title %}
+<section class="latest-proof" aria-labelledby="latest-proof-heading">
+  <div class="align-container">
+    <article class="latest-proof__card">
+      <header class="latest-proof__header">
+        <p class="section-label">Latest Proof</p>
+        <h2 id="latest-proof-heading">Proof {{ latestProof.case_id }} — {{ latestProof.title }}</h2>
+        <p class="latest-proof__summary">{{ latestProof.thesis }}</p>
+      </header>
+
+      <div class="latest-proof__grid">
+        <dl class="latest-proof__meta">
+          <div>
+            <dt>Case Brief</dt>
+            <dd><a href="{{ latestCaseUrl }}">{{ latestCaseTitle }}</a></dd>
+          </div>
+          {% if latestProof.date %}
+          <div>
+            <dt>Filed</dt>
+            <dd>{{ latestProof.date | date }}</dd>
+          </div>
+          {% endif %}
+          {% if latestProof.category %}
+          <div>
+            <dt>Category</dt>
+            <dd>{{ latestProof.category }}</dd>
+          </div>
+          {% endif %}
+        </dl>
+
+        <div class="latest-proof__detail">
+          {% if latestProof.violation %}
+          <h3>Violation</h3>
+          <p>{{ latestProof.violation | safe }}</p>
+          {% endif %}
+          {% if latestProof.stakes %}
+          <h3>Stakes</h3>
+          <p>{{ latestProof.stakes | safe }}</p>
+          {% endif %}
+        </div>
+      </div>
+
+      <div class="latest-proof__actions">
+        <a href="{{ latestProofUrl }}" class="btn btn-accent">Examine Proof</a>
+        <a href="{{ latestCaseUrl }}" class="btn btn-outline-blue">View Case Brief</a>
+      </div>
+    </article>
+  </div>
+</section>
+{% endif %}
+
 {% if featuredCases and featuredCases | length %}
 <section class="key-cases" id="key-cases" aria-labelledby="key-cases-heading">
   <div class="align-container">
@@ -66,6 +123,19 @@ reviewDate: 2024-12-01
     <div class="key-case-actions">
       <a href="{{ '/overproofs/' | url }}" class="btn btn-outline-blue">View all case briefs</a>
     </div>
+  </div>
+</section>
+{% endif %}
+
+{% set caseStudies = collections.caseStudies %}
+{% if caseStudies and caseStudies | length %}
+<section class="case-files" id="case-files" aria-labelledby="case-files-heading">
+  <div class="align-container">
+    <p class="section-label">Case Files</p>
+    <h2 id="case-files-heading">Case Brief Archive</h2>
+    <p class="lead">Browse every active case file to understand how the documented proofs come together.</p>
+
+    {% include "case-study-list.njk" with { studies: caseStudies } %}
   </div>
 </section>
 {% endif %}

--- a/style.css
+++ b/style.css
@@ -833,6 +833,102 @@ p{
   margin-top: var(--space-2);
 }
 
+/* Latest Proof */
+.latest-proof{
+  padding: calc(var(--space-8) + var(--space-4)) 0;
+  background:var(--color-surface-subtle);
+}
+.latest-proof__card{
+  background:var(--color-surface-raised);
+  border-radius:20px;
+  padding: clamp(var(--space-5), 4vw, var(--space-7));
+  box-shadow: var(--shadow-sm);
+  display:flex;
+  flex-direction:column;
+  gap: var(--space-6);
+  border:1px solid color-mix(in srgb, var(--color-border-subtle) 65%, transparent);
+}
+.latest-proof__summary{
+  font-size: clamp(var(--font-size-base), 1.15rem, var(--font-size-lg));
+  color:var(--color-text-muted);
+  margin:0;
+}
+.latest-proof__grid{
+  display:grid;
+  gap: var(--space-6);
+}
+.latest-proof__meta{
+  display:grid;
+  gap: var(--space-3);
+  margin:0;
+}
+.latest-proof__meta div{
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+}
+.latest-proof__meta dt{
+  font-size: var(--font-size-xs);
+  text-transform:uppercase;
+  letter-spacing:.5px;
+  color:var(--color-text-muted);
+  margin:0;
+}
+.latest-proof__meta dd{
+  margin:0;
+  font-weight:600;
+  font-size: var(--font-size-base);
+}
+.latest-proof__meta a{
+  color:var(--color-link-default);
+}
+.latest-proof__detail{
+  display:flex;
+  flex-direction:column;
+  gap: var(--space-4);
+}
+.latest-proof__detail h3{
+  margin:0;
+  font-size: var(--font-size-sm);
+  text-transform:uppercase;
+  letter-spacing:.5px;
+  color:var(--color-text-muted);
+}
+.latest-proof__detail p{
+  margin:0;
+  font-size: var(--font-size-base);
+  color:var(--color-text-base);
+}
+.latest-proof__actions{
+  display:flex;
+  flex-wrap:wrap;
+  gap: var(--space-3);
+}
+
+@media (min-width: 768px){
+  .latest-proof__grid{
+    grid-template-columns: minmax(220px, 1fr) minmax(260px, 1.2fr);
+    align-items:flex-start;
+  }
+  .latest-proof__detail{
+    padding-left: var(--space-2);
+  }
+}
+
+[data-theme="dark"] .latest-proof{
+  background:color-mix(in srgb, var(--color-surface-subtle) 60%, transparent);
+}
+[data-theme="dark"] .latest-proof__card{
+  background:var(--color-surface-raised);
+  border-color:color-mix(in srgb, var(--color-border-subtle) 70%, transparent);
+}
+[data-theme="dark"] .latest-proof__summary{
+  color:var(--color-text-muted);
+}
+[data-theme="dark"] .latest-proof__meta dt{
+  color:var(--color-text-muted);
+}
+
 /* Proof Box */
 .proof-box{
   background:var(--color-surface-raised);
@@ -998,11 +1094,43 @@ p{
 .case-card:hover .case-link::before{
   background-image:url('images/three-dots-gold.svg');
 }
+.case-card__footer{
+  margin-top:auto;
+  display:flex;
+  flex-direction:column;
+  gap: var(--space-3);
+  width:100%;
+}
+.case-link--subtle{
+  color:var(--color-text-muted);
+}
+.case-link--subtle::before{
+  width:16px;
+  height:16px;
+  opacity:.6;
+}
+.case-card:hover .case-link--subtle::before{
+  opacity:1;
+}
+[data-theme="dark"] .case-link--subtle{
+  color:color-mix(in srgb, var(--color-text-base) 80%, transparent);
+}
+[data-theme="dark"] .case-card:hover .case-link--subtle::before{
+  background-image:url('images/three-dots-gold.svg');
+}
 
 /* Featured cases */
 .key-cases{
   padding: calc(var(--space-8) + var(--space-4)) 0;
   background: var(--color-surface-subtle);
+}
+
+.case-files{
+  padding: calc(var(--space-8) + var(--space-4)) 0;
+  background: var(--paper);
+}
+[data-theme="dark"] .case-files{
+  background:color-mix(in srgb, var(--color-surface-subtle) 55%, transparent);
 }
 
 .key-case-grid{
@@ -3831,6 +3959,47 @@ html { scroll-behavior: smooth; }
   text-transform: uppercase;
   letter-spacing: 0.5px;
   color: var(--text);
+}
+
+.proof-related-case{
+  margin-top: var(--space-6);
+  padding: var(--space-5);
+  border-radius:16px;
+  background:var(--color-surface-subtle);
+  border:1px solid color-mix(in srgb, var(--color-border-subtle) 70%, transparent);
+  display:flex;
+  flex-direction:column;
+  gap: var(--space-4);
+}
+.proof-related-case__text{
+  display:flex;
+  flex-direction:column;
+  gap: var(--space-3);
+}
+.proof-related-case h2{
+  margin:0;
+  font-size: clamp(var(--font-size-lg), 2.2vw, var(--font-size-xl));
+}
+.proof-related-case p{
+  margin:0;
+  color:var(--color-text-muted);
+}
+@media (min-width: 768px){
+  .proof-related-case{
+    flex-direction:row;
+    align-items:center;
+    justify-content:space-between;
+  }
+  .proof-related-case__text{
+    max-width:60%;
+  }
+}
+[data-theme="dark"] .proof-related-case{
+  background:color-mix(in srgb, var(--color-surface-raised) 75%, transparent);
+  border-color:color-mix(in srgb, var(--color-border-subtle) 60%, transparent);
+}
+[data-theme="dark"] .proof-related-case p{
+  color:color-mix(in srgb, var(--color-text-base) 85%, transparent);
 }
 .proof-strength-bars {
   display: flex;


### PR DESCRIPTION
## Summary
- add a latest proof hero card on the homepage with clear links back to the related case brief and refreshed styling
- reuse a new case-study list partial so the full case file archive is listed on the homepage alongside the existing overproofs page
- update the proof archive and individual proof views to surface direct links to their case briefs with supportive UI polish

## Testing
- npm run build *(fails: esbuild not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d60de5f218833096f40a28cf20f7f7