### PR TITLE
Refine homepage proof spotlight and case layout

### DIFF
--- a/archive.njk
+++ b/archive.njk
@@ -27,6 +27,13 @@ reviewDate: 2024-12-01
     
     <div class="case-grid" id="case-grid" aria-live="polite">
       {%- for proof in collections.sortedProofs -%}
+      {% set caseUrl = null %}
+      {% set caseLabel = null %}
+      {% set proofOverproof = proof.overproof %}
+      {% if proofOverproof %}
+        {% set caseUrl = (proofOverproof.url or ('/briefs/' + proofOverproof.slug + '/')) | url %}
+        {% set caseLabel = proofOverproof.short_title or proofOverproof.title %}
+      {% endif %}
       <article class="case-card" data-proof-id="{{ proof.case_id }}">
         <h3><a href="{{ '/proofs/' | url }}{{ proof.overproof.slug }}/{{ proof.slug }}/">{{ proof.title }}</a></h3>
         <p class="case-meta">
@@ -34,7 +41,12 @@ reviewDate: 2024-12-01
           {%- if proof.category %} • <span style="font-weight: 700;">{{ proof.category }}</span>{% endif -%}
         </p>
         <p>{{ proof.thesis }}</p>
-        <a href="{{ '/proofs/' | url }}{{ proof.overproof.slug }}/{{ proof.slug }}/" class="case-link">Examine Proof →</a>
+        <div class="case-link-group">
+          <a href="{{ '/proofs/' | url }}{{ proof.overproof.slug }}/{{ proof.slug }}/" class="case-link">Examine Proof →</a>
+          {% if caseUrl %}
+          <a href="{{ caseUrl }}" class="case-link case-link--secondary"{% if caseLabel %} aria-label="View case file for {{ caseLabel }}"{% endif %}>View Case File →</a>
+          {% endif %}
+        </div>
       </article>
       {%- endfor -%}
     </div>

--- a/index.njk
+++ b/index.njk
@@ -5,13 +5,21 @@ description: Proof. Not spin. Democratic Justice equips West Virginia Democrats 
 reviewDate: 2024-12-01
 ---
 
-{% set featuredCases = collections.caseStudies | slice(0, 3) %}
+{% set latestProof = collections.sortedProofs | first %}
+{% set caseStudies = collections.caseStudies %}
 {% set totalProofs = collections.sortedProofs | length %}
+{% set latestCaseUrl = null %}
+{% set latestCaseLabel = null %}
+{% if latestProof and latestProof.overproof %}
+  {% set overproof = latestProof.overproof %}
+  {% set latestCaseUrl = (overproof.url or ('/briefs/' + overproof.slug + '/')) | url %}
+  {% set latestCaseLabel = overproof.short_title or overproof.title %}
+{% endif %}
 
 <header class="hero" role="banner">
   <div class="align-container">
-    <div class="hero-grid hero-grid--single">
-      <div>
+    <div class="hero-grid">
+      <div class="hero-copy">
         <h1 class="hero-headline">Proof.<strong>Not Spin.</strong></h1>
         <p class="hero-lede">We assemble sworn records into proof the stronger party can’t ignore—and put it in your hands so you can demand accountability.</p>
         <div class="btn-group">
@@ -23,48 +31,80 @@ reviewDate: 2024-12-01
           </a>
         </div>
       </div>
+      {% if latestProof and latestProof.overproof %}
+      <aside class="hero-latest-proof" aria-labelledby="latest-proof-heading">
+        <p class="hero-latest-proof__label">Latest Proof</p>
+        <article class="case-card hero-latest-proof__card" data-proof-id="{{ latestProof.case_id }}">
+          <div class="case-card__header">
+            <h2 class="case-card__title" id="latest-proof-heading"><a href="{{ '/proofs/' | url }}{{ latestProof.overproof.slug }}/{{ latestProof.slug }}/">{{ latestProof.title }}</a></h2>
+            <p class="case-meta case-card__meta">
+              PROOF {{ latestProof.case_id }} • {{ latestProof.date | date }}
+              {% if latestProof.category %} • <span style="font-weight: 700;">{{ latestProof.category }}</span>{% endif %}
+            </p>
+          </div>
+          {% if latestProof.thesis %}
+          <p class="case-card__summary">{{ latestProof.thesis }}</p>
+          {% endif %}
+          <div class="case-link-group">
+            <a class="case-link" href="{{ '/proofs/' | url }}{{ latestProof.overproof.slug }}/{{ latestProof.slug }}/">Read Full Proof →</a>
+            {% if latestCaseUrl %}
+            <a class="case-link case-link--secondary" href="{{ latestCaseUrl }}"{% if latestCaseLabel %} aria-label="View case file for {{ latestCaseLabel }}"{% endif %}>View Case File →</a>
+            {% endif %}
+          </div>
+        </article>
+      </aside>
+      {% endif %}
     </div>
   </div>
 </header>
 
-{% if featuredCases and featuredCases | length %}
-<section class="key-cases" id="key-cases" aria-labelledby="key-cases-heading">
+{% if caseStudies and caseStudies | length %}
+<section class="cases" id="case-files" aria-labelledby="case-files-heading">
   <div class="align-container">
-    <p class="section-label">Investigative Briefs</p>
-    <h2 id="key-cases-heading">Key Cases</h2>
-    <p class="lead">Start with the major violations our research has proven. Each case brief connects the documents, testimony, and rulings into a clear narrative.</p>
+    <p class="section-label">Case Files</p>
+    <h2 id="case-files-heading">Explore the Case Files</h2>
+    <p class="lead">Every case file gathers the sworn documents, testimony, and rulings that establish a major violation. Start with a case to see every proof in context.</p>
 
-    <div class="key-case-grid">
-      {% for study in featuredCases %}
+    <div class="case-file-list">
+      {% for study in caseStudies %}
         {% set overproofGroup = study.data.overproofGroup %}
-        {% set overproof = overproofGroup.overproof %}
-        {% set brief = overproof.brief %}
-        {% set caseTitle = (brief and brief.headline) or overproof.short_title or overproof.title %}
-        {% set caseSummary = study.data.description or (brief and brief.lede) or overproof.summary %}
-        {% set proofCount = overproof.proofCount or (overproofGroup.proofs | length) %}
-        <article class="key-case-card">
-          {% if overproof.umbrella_category %}
-          <p class="key-case-card__kicker">VIOLATION: {{ overproof.umbrella_category }}</p>
-          {% endif %}
-          <h3><a href="{{ study.url | url }}">{{ caseTitle }}</a></h3>
-          {% if caseSummary %}
-          <p class="key-case-card__summary">{{ caseSummary | truncate(210) }}</p>
-          {% endif %}
-          <div class="key-case-card__meta">
-            {% if proofCount %}
-            <span>{{ proofCount }} documented proofs</span>
+        {% set caseOverproof = overproofGroup.overproof %}
+        {% set brief = caseOverproof.brief %}
+        {% set caseTitle = (brief and brief.headline) or caseOverproof.short_title or caseOverproof.title or study.data.title %}
+        {% set caseSummary = study.data.description or (brief and brief.lede) or caseOverproof.summary %}
+        {% set proofCount = caseOverproof.proofCount or (overproofGroup.proofs | length) %}
+        {% set timeframe = caseOverproof.metadata and caseOverproof.metadata.Timeframe %}
+        {% set hasStats = proofCount or timeframe %}
+        {% set caseUrl = study.url | url %}
+        <article class="case-file-row">
+          <div class="case-file-row__details">
+            {% if caseOverproof.umbrella_category %}
+            <p class="case-file-row__kicker">Violation: {{ caseOverproof.umbrella_category }}</p>
             {% endif %}
-            {% if overproof.metadata and overproof.metadata.Timeframe %}
-            <span>{{ overproof.metadata.Timeframe }}</span>
+            <h3 class="case-file-row__title"><a href="{{ caseUrl }}">{{ caseTitle }}</a></h3>
+            {% if caseSummary %}
+            <p class="case-file-row__summary">{{ caseSummary | truncate(220) }}</p>
             {% endif %}
           </div>
-          <a class="key-case-card__cta" href="{{ study.url | url }}">Read case brief →</a>
+          <div class="case-file-row__meta">
+            {% if hasStats %}
+            <ul class="case-file-row__stats">
+              {% if proofCount %}
+              <li><strong>{{ proofCount }}</strong> documented proofs</li>
+              {% endif %}
+              {% if timeframe %}
+              <li>{{ timeframe }}</li>
+              {% endif %}
+            </ul>
+            {% endif %}
+            <a class="case-link case-file-row__cta" href="{{ caseUrl }}">Open Case File →</a>
+          </div>
         </article>
       {% endfor %}
     </div>
 
-    <div class="key-case-actions">
-      <a href="{{ '/overproofs/' | url }}" class="btn btn-outline-blue">View all case briefs</a>
+    <div class="case-actions">
+      <a href="{{ '/overproofs/' | url }}" class="btn btn-outline-blue">Browse all case files</a>
     </div>
   </div>
 </section>

--- a/style.css
+++ b/style.css
@@ -740,20 +740,51 @@ p{
   display: grid;
   grid-template-columns: 1fr;
   gap: var(--space-7);
-  align-items: center;
+  align-items: start;
 }
 @media (min-width:769px){
-  .hero-grid{ grid-template-columns: 1.3fr 1fr; }
+  .hero-grid{ grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr); }
 }
 
-.hero-grid--single{
-  grid-template-columns: 1fr;
+.hero-copy{
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.hero-latest-proof{
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  align-self: stretch;
 }
 
 @media (min-width:769px){
-  .hero-grid--single{
-    grid-template-columns: minmax(0, 1fr);
+  .hero-latest-proof{
+    justify-self: end;
   }
+}
+
+.hero-latest-proof__label{
+  font-family: 'Oswald',Impact,sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  font-size: var(--font-size-sm);
+  color: color-mix(in srgb, var(--white) 80%, transparent);
+}
+
+.hero-latest-proof__card{
+  margin: 0;
+  max-width: 420px;
+  box-shadow: var(--shadow-md);
+}
+
+.hero-latest-proof__card .case-card__title a{
+  font-size: clamp(1.25rem, 2.5vw, 1.5rem);
+}
+
+.hero-latest-proof__card .case-card__summary{
+  color: var(--color-text-base);
 }
 /* Buttons */
 .btn{
@@ -905,11 +936,100 @@ p{
   padding: calc(var(--space-8) + var(--space-6)) 0;
   background:var(--color-surface-subtle);
 }
-.case-grid{
-  display:grid;
-  grid-template-columns:1fr;
+.case-file-list{
+  display:flex;
+  flex-direction:column;
   gap: var(--space-5);
   margin-top: var(--space-7);
+}
+
+.case-file-row{
+  background:var(--color-surface-raised);
+  border-left:4px solid var(--color-primary-800);
+  border-radius:12px;
+  padding: var(--space-5);
+  display:flex;
+  flex-direction:column;
+  gap: var(--space-5);
+  box-shadow:var(--shadow-sm);
+}
+
+.case-file-row__details{
+  display:flex;
+  flex-direction:column;
+  gap: var(--space-3);
+}
+
+.case-file-row__kicker{
+  margin:0;
+  font-size: var(--font-size-sm);
+  font-weight:600;
+  text-transform:uppercase;
+  letter-spacing:.5px;
+  color: var(--color-text-muted);
+}
+
+.case-file-row__title{
+  margin:0;
+  font-size: clamp(1.5rem, 2.6vw, 1.75rem);
+}
+
+.case-file-row__title a{
+  text-decoration:none;
+}
+
+.case-file-row__title a:hover,
+.case-file-row__title a:focus{
+  text-decoration:underline;
+}
+
+.case-file-row__summary{
+  margin:0;
+  color: var(--color-text-base);
+}
+
+.case-file-row__meta{
+  display:flex;
+  flex-direction:column;
+  gap: var(--space-4);
+}
+
+.case-file-row__stats{
+  margin:0;
+  padding:0;
+  list-style:none;
+  display:flex;
+  flex-wrap:wrap;
+  gap: var(--space-4);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.case-file-row__stats strong{
+  font-size: var(--font-size-md);
+  color: var(--color-text-base);
+}
+
+.case-file-row__cta{
+  align-self:flex-start;
+}
+
+@media (min-width: 960px){
+  .case-file-row{
+    flex-direction:row;
+    align-items:center;
+    justify-content:space-between;
+  }
+
+  .case-file-row__meta{
+    align-items:flex-end;
+    text-align:right;
+    max-width: 260px;
+  }
+
+  .case-file-row__stats{
+    justify-content:flex-end;
+  }
 }
 .case-card{
   background:var(--color-surface-raised);
@@ -955,9 +1075,35 @@ p{
 .case-card__summary{
   margin: var(--space-5) 0 var(--space-4);
 }
+.case-card__meta-list{
+  display:flex;
+  flex-wrap:wrap;
+  gap: var(--space-3);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  margin: var(--space-4) 0;
+}
+.case-card__meta-list span{
+  display:inline-flex;
+  align-items:center;
+  gap: var(--space-2);
+}
+.case-card__meta-list span::before{
+  content:"";
+  display:inline-block;
+  width:6px;
+  height:6px;
+  background:currentColor;
+  border-radius:50%;
+}
+.case-card__meta-list span:first-child::before{
+  display:none;
+}
+.case-card h2 a,
 .case-card h3 a{
   color:var(--color-text-base);
 }
+.case-card h2 a:hover,
 .case-card h3 a:hover{
   color:var(--color-link-hover);
 }
@@ -982,6 +1128,7 @@ p{
   align-self:flex-start;
   justify-content:flex-start;
 }
+[data-theme="dark"] .case-card h2 a,
 [data-theme="dark"] .case-card h3 a,
 [data-theme="dark"] .case-link{
   color:var(--color-text-base);
@@ -997,6 +1144,31 @@ p{
 }
 .case-card:hover .case-link::before{
   background-image:url('images/three-dots-gold.svg');
+}
+.case-link-group{
+  display:flex;
+  flex-wrap:wrap;
+  gap: var(--space-4);
+  margin-top: var(--space-4);
+}
+.case-link-group .case-link{
+  margin-top:0;
+}
+.case-link--secondary{
+  color: var(--color-text-muted);
+}
+.case-link--secondary:hover,
+.case-link--secondary:focus-visible{
+  color: var(--color-link-hover);
+}
+.case-link--secondary::before{
+  background-image:url('images/three-dots-gold.svg');
+}
+.case-actions{
+  margin-top: var(--space-7);
+  display:flex;
+  flex-wrap:wrap;
+  gap: var(--space-3);
 }
 
 /* Featured cases */


### PR DESCRIPTION
## Summary
- surface the latest proof inside the hero so the featured evidence returns to the top of the homepage
- reshape the case file listing into horizontal rows that emphasize each case without side-by-side cards
- add supporting hero and case layout styles for the new hierarchy

## Testing
- npm run build *(fails: esbuild binary unavailable before dependencies are installed in this environment)*
- npm install *(fails: puppeteer cannot download Chromium because HTTPS requests are blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d614bf0b288330be475a6e2c1123c6