### PR TITLE
Restore compact hero proof card layout

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -34,18 +34,19 @@ reviewDate: 2024-12-01
       {% if latestProof and latestProof.overproof %}
       <aside class="hero-latest-proof" aria-labelledby="latest-proof-heading">
         <p class="hero-latest-proof__label">Latest Proof</p>
-        <article class="case-card hero-latest-proof__card" data-proof-id="{{ latestProof.case_id }}">
+        <article class="case-card case-card--compact hero-latest-proof__card" data-proof-id="{{ latestProof.case_id }}">
+          <p class="case-card__kicker">Proof {{ latestProof.case_id }}</p>
           <div class="case-card__header">
             <h2 class="case-card__title" id="latest-proof-heading"><a href="{{ '/proofs/' | url }}{{ latestProof.overproof.slug }}/{{ latestProof.slug }}/">{{ latestProof.title }}</a></h2>
-            <p class="case-meta case-card__meta">
-              PROOF {{ latestProof.case_id }} • {{ latestProof.date | date }}
-              {% if latestProof.category %} • <span style="font-weight: 700;">{{ latestProof.category }}</span>{% endif %}
+            <p class="case-meta case-card__meta case-card__meta--inline">
+              {{ latestProof.date | date }}
+              {% if latestProof.category %} • <span>{{ latestProof.category }}</span>{% endif %}
             </p>
           </div>
           {% if latestProof.thesis %}
-          <p class="case-card__summary">{{ latestProof.thesis }}</p>
+          <p class="case-card__summary case-card__summary--compact">{{ latestProof.thesis }}</p>
           {% endif %}
-          <div class="case-link-group">
+          <div class="case-card__footer">
             <a class="case-link" href="{{ '/proofs/' | url }}{{ latestProof.overproof.slug }}/{{ latestProof.slug }}/">Read Full Proof →</a>
             {% if latestCaseUrl %}
             <a class="case-link case-link--secondary" href="{{ latestCaseUrl }}"{% if latestCaseLabel %} aria-label="View case file for {{ latestCaseLabel }}"{% endif %}>View Case File →</a>

--- a/style.css
+++ b/style.css
@@ -1042,6 +1042,10 @@ p{
   flex-direction:column;
   align-items:flex-start;
 }
+.case-card--compact{
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-5);
+}
 .case-card:hover{
   transform:translateY(-2px);
   box-shadow:var(--shadow-md);
@@ -1063,6 +1067,15 @@ p{
   width:100%;
 }
 
+.case-card__kicker{
+  font-family:'Oswald',Impact,sans-serif;
+  text-transform:uppercase;
+  font-size:var(--font-size-xs);
+  letter-spacing:1.6px;
+  color:color-mix(in srgb, var(--color-text-muted) 90%, transparent);
+  margin:0;
+}
+
 .case-card__title{
   margin:0;
   text-align:left;
@@ -1072,8 +1085,35 @@ p{
   margin:0;
 }
 
+.case-card__meta--inline{
+  display:flex;
+  flex-wrap:wrap;
+  gap:var(--space-2);
+}
+
+.case-card__meta--inline span{
+  font-weight:700;
+}
+
 .case-card__summary{
   margin: var(--space-5) 0 var(--space-4);
+}
+
+.case-card__summary--compact{
+  margin:0;
+  color:color-mix(in srgb, var(--color-text-base) 88%, transparent);
+  line-height:1.45;
+  display:-webkit-box;
+  -webkit-line-clamp:3;
+  -webkit-box-orient:vertical;
+  overflow:hidden;
+}
+
+.case-card__footer{
+  display:flex;
+  flex-wrap:wrap;
+  gap:var(--space-3);
+  margin-top:auto;
 }
 .case-card__meta-list{
   display:flex;


### PR DESCRIPTION
## Summary
- restyle the homepage hero proof card with a compact kicker, inline metadata, and tighter summary spacing
- add reusable compact case card styles so the hero matches the established proof presentation

## Testing
- ⚠️ `npm install` *(fails: Chromium download blocked because only http protocol is allowed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d62a81a1348330a67d73db3c4f76ec