### PR TITLE
Remove hero lede paragraph from homepage hero

### DIFF
--- a/index.njk
+++ b/index.njk
@@ -21,7 +21,6 @@ reviewDate: 2024-12-01
     <div class="hero-grid">
       <div class="hero-copy">
         <h1 class="hero-headline">Proof.<strong>Not Spin.</strong></h1>
-        <p class="hero-lede">We assemble sworn records into proof the stronger party can’t ignore—and put it in your hands so you can demand accountability.</p>
         <div class="btn-group">
           <a href="{{ '/overproofs/' | url }}" class="btn btn-accent">
             Explore Overproofs


### PR DESCRIPTION
## Summary
- remove the hero lede paragraph from the homepage hero copy so only the headline and button group remain

## Testing
- npm run build *(fails: `critical: Failed to extract CSS` because Chromium cannot be downloaded in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d70ab93d78833098db5b5690de2d7b